### PR TITLE
이메일 인증 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ modules/
 .calva/output-window/
 .lsp/.cache/
 .clj-kondo/imports/
+
+# secrets
+secrets.edn

--- a/deps.edn
+++ b/deps.edn
@@ -27,10 +27,11 @@
            com.github.seancorfield/next.jdbc {:mvn/version "1.3.909"}
            org.postgresql/postgresql {:mvn/version "42.6.0"}
            buddy/buddy-auth {:mvn/version "3.0.1"}
-           buddy/buddy-sign {:mvn/version "3.4.1"}
+           buddy/buddy-sign {:mvn/version "3.5.351"}
            buddy/buddy-hashers {:mvn/version "2.0.167"}
            clj-time/clj-time {:mvn/version "0.15.2"}
-           failjure/failjure {:mvn/version "2.3.0"}}
+           failjure/failjure {:mvn/version "2.3.0"}
+           com.draines/postal {:mvn/version "2.0.5"}}
 
  :aliases {:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}}
                    :ns-default build}

--- a/resources/system.edn
+++ b/resources/system.edn
@@ -106,7 +106,10 @@
  {:with-tx #ig/ref :db/tx-manager
   :user-repository #ig/ref :infrastructure/user-repository
   :event-subscriber #ig/ref :infrastructure/event-bus
-  :password-gateway #ig/ref :auth/bcrypt-password-gateway}
+  :password-gateway #ig/ref :auth/bcrypt-password-gateway
+  :token-gateway #ig/ref :auth/jwt
+  :email-gateway #ig/ref :infrastructure/email-gateway
+  :email-token-gateway #ig/ref :infrastructure/email-token-gateway}
 
  :domain/role-request-use-case
  {:with-tx #ig/ref :db/tx-manager
@@ -121,4 +124,16 @@
 
  :web.middleware/auth
  {:auth-gateway #ig/ref :auth/jwt}
+
+ :infrastructure/email-gateway
+ {:smtp-config {:host #or [#env SMTP_HOST "smtp.gmail.com"]
+               :port #long #or [#env SMTP_PORT 587]
+               :user #env SMTP_USER
+               :pass #env SMTP_PASS
+               :tls true
+               :from #or [#env SMTP_FROM "noreply@spookytown.com"]}
+  :base-url #or [#env BASE_URL "http://localhost:3000"]}
+
+ :infrastructure/email-token-gateway
+ {:secret #or [#env EMAIL_TOKEN_SECRET "ANOTHER_SECRET_HERE"]}
 }

--- a/src/clj/kit/spooky_town/core.clj
+++ b/src/clj/kit/spooky_town/core.clj
@@ -18,6 +18,7 @@
    ;; Infrastructure
    [kit.spooky-town.infrastructure.email.smtp-gateway]
    [kit.spooky-town.infrastructure.auth.jwt-email-token-gateway]
+   [kit.spooky-town.infrastructure.auth.bcrypt-gateway]
 
    ;; Database
    [kit.spooky-town.infrastructure.persistence.core]

--- a/src/clj/kit/spooky_town/core.clj
+++ b/src/clj/kit/spooky_town/core.clj
@@ -11,11 +11,13 @@
    [kit.edge.db.sql.conman]
    [kit.edge.db.sql.migratus]
 
-
-
    ;; Routes
    [kit.spooky-town.web.routes.api]
    [kit.spooky-town.web.middleware.auth]
+
+   ;; Infrastructure
+   [kit.spooky-town.infrastructure.email.smtp-gateway]
+   [kit.spooky-town.infrastructure.auth.jwt-email-token-gateway]
 
    ;; Database
    [kit.spooky-town.infrastructure.persistence.core]

--- a/src/clj/kit/spooky_town/domain/user/gateway/email.clj
+++ b/src/clj/kit/spooky_town/domain/user/gateway/email.clj
@@ -1,0 +1,11 @@
+(ns kit.spooky-town.domain.user.gateway.email)
+
+(defprotocol EmailGateway
+  (send-verification-email [this email token]
+    "회원가입 이메일 인증 메일을 발송합니다.")
+  
+  (send-password-reset-email [this email token]
+    "비밀번호 초기화 메일을 발송합니다.")
+  
+  (send-email-change-verification [this email token]
+    "이메일 변경 인증 메일을 발송합니다.")) 

--- a/src/clj/kit/spooky_town/domain/user/gateway/email_token.clj
+++ b/src/clj/kit/spooky_town/domain/user/gateway/email_token.clj
@@ -1,0 +1,8 @@
+(ns kit.spooky-town.domain.user.gateway.email-token)
+
+(defprotocol EmailTokenGateway
+  (generate-token [this email purpose]
+    "주어진 용도(가입/초기화/변경)에 맞는 이메일 인증 토큰을 생성합니다.")
+  
+  (verify-token [this token]
+    "토큰을 검증하고 이메일과 용도를 반환합니다.")) 

--- a/src/clj/kit/spooky_town/domain/user/gateway/email_verification.clj
+++ b/src/clj/kit/spooky_town/domain/user/gateway/email_verification.clj
@@ -1,0 +1,14 @@
+(ns kit.spooky-town.domain.user.gateway.email-verification)
+
+(defprotocol EmailVerificationGateway
+  (save-verification-status! [this email purpose status]
+    "이메일 인증 상태를 저장합니다.
+     status는 :pending, :verified 중 하나입니다.")
+  
+  (get-verification-status [this email purpose]
+    "이메일의 인증 상태를 조회합니다.
+     {:status :pending/:verified, :verified-at timestamp} 형태로 반환합니다.
+     상태가 없으면 nil을 반환합니다.")
+  
+  (has-verified? [this email purpose]
+    "해당 이메일이 특정 용도로 인증되었는지 확인합니다.")) 

--- a/src/clj/kit/spooky_town/domain/user/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/user/use_case.clj
@@ -4,6 +4,8 @@
    [integrant.core :as ig]
    [kit.spooky-town.domain.event :as event]
    [kit.spooky-town.domain.user.entity :as entity :refer [admin?]]
+   [kit.spooky-town.domain.user.gateway.email :as email-gateway]
+   [kit.spooky-town.domain.user.gateway.email-token :as email-token-gateway]
    [kit.spooky-town.domain.user.gateway.password :as password-gateway]
    [kit.spooky-town.domain.user.gateway.token :as token-gateway]
    [kit.spooky-town.domain.user.repository.protocol :refer [find-by-email
@@ -24,14 +26,22 @@
     "사용자의 역할을 업데이트합니다.")
   (init [this]
     "이벤트 구독을 초기화합니다.")
- (request-password-reset [this command]
-                         "비밀번호 초기화를 요청합니다.")
- (reset-password [this command]
-                 "비밀번호를 초기화합니다.")
+  (request-password-reset [this command]
+    "비밀번호 초기화를 요청합니다.")
+  (reset-password [this command]
+    "비밀번호를 초기화합니다.")
   (withdraw [this command]
     "사용자가 회원 탈퇴를 진행합니다.")
   (delete-user [this command]
-    "관리자가 사용자를 탈퇴 처리합니다."))
+    "관리자가 사용자를 탈퇴 처리합니다.")
+  (request-email-verification [this email purpose]
+    "이메일 인증을 요청합니다. 
+     purpose는 :registration, :password-reset, :email-change 중 하나입니다.")
+  (verify-email [this token]
+    "토큰을 검증하고 이메일 인증을 완료합니다.
+     성공 시 이메일과 용도를 반환합니다.")
+  (check-email-verification-status [this email]
+    "해당 이메일의 인증 상태를 확인합니다."))
 
 (def token-expires-in-sec (* 60 60 24))
 
@@ -45,7 +55,7 @@
 
 (defrecord DeleteUserCommand [admin-uuid user-uuid reason])
 
-(defrecord UserUseCaseImpl [with-tx password-gateway token-gateway user-repository event-subscriber]
+(defrecord UserUseCaseImpl [with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway]
   UserUseCase
   (register-user [_ {:keys [email name password]}]
     (f/attempt-all
@@ -229,8 +239,36 @@
                    withdrawn-user (entity/mark-as-withdrawn user reason)
                    _ (save! repo withdrawn-user)]
                   true)))]
-     {:success true})))
+     {:success true}))
+
+  (request-email-verification [_ email purpose]
+    (if-not (#{:registration :password-reset :email-change} purpose)
+      (f/fail :email-verification/invalid-purpose)
+      (f/attempt-all
+        [token (email-token-gateway/generate-token email-token-gateway email purpose)
+         _ (case purpose
+             :registration (email-gateway/send-verification-email email-gateway email token)
+             :password-reset (email-gateway/send-password-reset-email email-gateway email token)
+             :email-change (email-gateway/send-email-change-verification email-gateway email token))]
+        {:token token}
+        (f/when-failed [e]
+          (f/fail :email-verification/failed)))))
+
+  (verify-email [_ token]
+    (if (empty? token)
+      (f/fail :email-verification/invalid-token)
+      (f/attempt-all
+        [{:keys [email purpose] :as result} (email-token-gateway/verify-token email-token-gateway token)]
+        result
+        (f/when-failed [e]
+          (f/fail :email-verification/invalid-token)))))
+
+  (check-email-verification-status [_ email]
+    (if (empty? email)
+      (f/fail :email-verification/invalid-email)
+      ;; TODO: 이메일 인증 상태 저장/조회 로직 구현 필요
+      (f/fail :email-verification/not-implemented))))
 
 (defmethod ig/init-key :domain/user-use-case
-  [_ {:keys [with-tx password-gateway token-gateway user-repository event-subscriber]}]
-  (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber))
+  [_ {:keys [with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway]}]
+  (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway))

--- a/src/clj/kit/spooky_town/infrastructure/auth/bcrypt_gateway.clj
+++ b/src/clj/kit/spooky_town/infrastructure/auth/bcrypt_gateway.clj
@@ -1,6 +1,7 @@
 (ns kit.spooky-town.infrastructure.auth.bcrypt-gateway
   (:require [kit.spooky-town.domain.user.gateway.password :refer [PasswordGateway]]
-            [buddy.hashers :as hashers]))
+            [buddy.hashers :as hashers]
+            [integrant.core :as ig]))
 
 (defrecord BCryptPasswordGateway []
   PasswordGateway
@@ -9,4 +10,9 @@
     (hashers/derive password {:alg :bcrypt+sha512}))
   
   (verify-password [_ password hashed-password]
-    (hashers/check password hashed-password))) 
+    (hashers/check password hashed-password)))
+
+;; Integrant init-key 메서드 추가
+(defmethod ig/init-key :auth/bcrypt-password-gateway
+  [_ _]
+  (->BCryptPasswordGateway)) 

--- a/src/clj/kit/spooky_town/infrastructure/auth/jwt_email_token_gateway.clj
+++ b/src/clj/kit/spooky_town/infrastructure/auth/jwt_email_token_gateway.clj
@@ -1,0 +1,31 @@
+(ns kit.spooky-town.infrastructure.auth.jwt-email-token-gateway
+  (:require [kit.spooky-town.domain.user.gateway.email-token :as email-token-gateway]
+            [buddy.sign.jwt :as jwt]
+            [failjure.core :as f]
+            [integrant.core :as ig]))
+
+(def expiration-times
+  {:registration    (* 24 60 60)  ; 24시간
+   :password-reset  (* 1 60 60)   ; 1시간
+   :email-change    (* 1 60 60)}) ; 1시간
+
+(defrecord JWTEmailTokenGateway [secret]
+  email-token-gateway/EmailTokenGateway
+  (generate-token [_ email purpose]
+    (let [exp (get expiration-times purpose (* 24 60 60))
+          claims {:email email
+                 :purpose purpose
+                 :exp (+ (quot (System/currentTimeMillis) 1000) exp)}]
+      (jwt/sign claims secret)))
+  
+  (verify-token [_ token]
+    (try
+      (let [claims (jwt/unsign token secret)]
+        {:email (:email claims)
+         :purpose (keyword (:purpose claims))})
+      (catch Exception _
+        (f/fail :invalid-token)))))
+
+(defmethod ig/init-key :infrastructure/email-token-gateway
+  [_ {:keys [secret]}]
+  (->JWTEmailTokenGateway secret)) 

--- a/src/clj/kit/spooky_town/infrastructure/email/smtp_gateway.clj
+++ b/src/clj/kit/spooky_town/infrastructure/email/smtp_gateway.clj
@@ -1,0 +1,62 @@
+(ns kit.spooky-town.infrastructure.email.smtp-gateway
+  (:require [kit.spooky-town.domain.user.gateway.email :as email-gateway]
+            [postal.core :as postal]
+            [integrant.core :as ig]))
+
+(def templates
+  {:registration
+   {:subject "스푸키 타운 회원가입 인증"
+    :body (fn [url] 
+            {:text (str "회원가입을 완료하려면 다음 링크를 클릭하세요: " url)
+             :html (str "<p>회원가입을 완료하려면 다음 링크를 클릭하세요:</p>"
+                       "<p><a href='" url "'>회원가입 인증하기</a></p>")})}
+   
+   :password-reset
+   {:subject "스푸키 타운 비밀번호 초기화"
+    :body (fn [url]
+            {:text (str "비밀번호를 초기화하려면 다음 링크를 클릭하세요: " url)
+             :html (str "<p>비밀번호를 초기화하려면 다음 링크를 클릭하세요:</p>"
+                       "<p><a href='" url "'>비밀번호 초기화하기</a></p>")})}
+   
+   :email-change
+   {:subject "스푸키 타운 이메일 변경 인증"
+    :body (fn [url]
+            {:text (str "이메일 변경을 완료하려면 다음 링크를 클릭하세요: " url)
+             :html (str "<p>이메일 변경을 완료하려면 다음 링크를 클릭하세요:</p>"
+                       "<p><a href='" url "'>이메일 변경 인증하기</a></p>")})}})
+
+(defrecord SMTPEmailGateway [smtp-config base-url]
+  email-gateway/EmailGateway
+  (send-verification-email [_ email token]
+    (let [url (str base-url "/verify-email?token=" token)
+          template (get-in templates [:registration])
+          body ((:body template) url)]
+      (postal/send-message smtp-config
+                          {:from (:from smtp-config)
+                           :to email
+                           :subject (:subject template)
+                           :body [:alternative body]})))
+  
+  (send-password-reset-email [_ email token]
+    (let [url (str base-url "/reset-password?token=" token)
+          template (get-in templates [:password-reset])
+          body ((:body template) url)]
+      (postal/send-message smtp-config
+                          {:from (:from smtp-config)
+                           :to email
+                           :subject (:subject template)
+                           :body [:alternative body]})))
+  
+  (send-email-change-verification [_ email token]
+    (let [url (str base-url "/verify-email-change?token=" token)
+          template (get-in templates [:email-change])
+          body ((:body template) url)]
+      (postal/send-message smtp-config
+                          {:from (:from smtp-config)
+                           :to email
+                           :subject (:subject template)
+                           :body [:alternative body]}))))
+
+(defmethod ig/init-key :infrastructure/email-gateway
+  [_ {:keys [smtp-config base-url]}]
+  (->SMTPEmailGateway smtp-config base-url)) 

--- a/src/clj/kit/spooky_town/web/controllers/user.clj
+++ b/src/clj/kit/spooky_town/web/controllers/user.clj
@@ -131,3 +131,38 @@
         (response/internal-server-error {:error "알 수 없는 오류가 발생했습니다"}))
       (response/ok result))))
 
+(defn request-email-verification
+  [{:keys [user-use-case body-params]}]
+  (let [result (use-case/request-email-verification 
+                user-use-case 
+                (:email body-params)
+                :registration)]
+    (if (f/failed? result)
+      (case (f/message result)
+        :email-verification/user-not-found
+        (response/not-found {:error "사용자를 찾을 수 없습니다"})
+        :email-verification/invalid-email
+        (response/bad-request {:error "유효하지 않은 이메일입니다"})
+        :email-verification/invalid-purpose
+        (response/bad-request {:error "유효하지 않은 목적입니다"})
+        :email-verification/failed
+        (response/internal-server-error {:error "이메일 인증 링크 발송에 실패했습니다"})
+        (response/internal-server-error {:error "알 수 없는 오류가 발생했습니다"}))
+      (response/ok {:message "이메일 인증 링크가 발송되었습니다"}))))
+
+(defn verify-email
+  [{:keys [user-use-case body-params]}]
+  (let [result (use-case/verify-email 
+                user-use-case 
+                (:token body-params))]
+    (if (f/failed? result)
+      (case (f/message result)
+        :email-verification/invalid-token
+        (response/bad-request {:error "유효하지 않은 토큰입니다"})
+        :email-verification/token-expired
+        (response/bad-request {:error "만료된 토큰입니다"})
+        :email-verification/user-not-found
+        (response/not-found {:error "사용자를 찾을 수 없습니다"})
+        (response/internal-server-error {:error "알 수 없는 오류가 발생했습니다"}))
+      (response/ok {:message "이메일 인증이 완료되었습니다"}))))
+

--- a/src/clj/kit/spooky_town/web/routes/admin.clj
+++ b/src/clj/kit/spooky_town/web/routes/admin.clj
@@ -1,0 +1,21 @@
+(ns kit.spooky-town.web.routes.admin
+  (:require [kit.spooky-town.web.controllers.user :as user]))
+
+(defn admin-routes [{:keys [user-use-case]}]
+  ["/admin"
+   ["/users"
+    ["/:id"
+     {:delete {:handler (fn [req]
+                         (user/delete-user
+                          (assoc req :user-use-case user-use-case)))
+               :parameters {:path [:map [:id :string]]
+                          :body [:map [:reason :string]]}
+               :responses {204 {}
+                         400 {:body [:map [:error :string]]}
+                         403 {:body [:map [:error :string]]}
+                         404 {:body [:map [:error :string]]}
+                         500 {:body [:map [:error :string]]}}
+               :summary "관리자가 사용자를 탈퇴 처리합니다"
+               :description "관리자 권한으로 특정 사용자를 탈퇴 처리합니다."
+               :swagger {:tags ["admin"]
+                        :security [{:bearer []}]}}}]]]) 

--- a/src/clj/kit/spooky_town/web/routes/admin.clj
+++ b/src/clj/kit/spooky_town/web/routes/admin.clj
@@ -1,21 +1,23 @@
 (ns kit.spooky-town.web.routes.admin
-  (:require [kit.spooky-town.web.controllers.user :as user]))
+  (:require [kit.spooky-town.web.controllers.user :as user]
+            [kit.spooky-town.web.routes.api :refer [authenticated-route-data]]))
 
 (defn admin-routes [{:keys [user-use-case]}]
   ["/admin"
-   ["/users"
-    ["/:id"
-     {:delete {:handler (fn [req]
-                         (user/delete-user
-                          (assoc req :user-use-case user-use-case)))
-               :parameters {:path [:map [:id :string]]
-                          :body [:map [:reason :string]]}
-               :responses {204 {}
-                         400 {:body [:map [:error :string]]}
-                         403 {:body [:map [:error :string]]}
-                         404 {:body [:map [:error :string]]}
-                         500 {:body [:map [:error :string]]}}
-               :summary "관리자가 사용자를 탈퇴 처리합니다"
-               :description "관리자 권한으로 특정 사용자를 탈퇴 처리합니다."
-               :swagger {:tags ["admin"]
-                        :security [{:bearer []}]}}}]]]) 
+   (merge authenticated-route-data
+          {"/users"
+           ["/:id"
+            {:delete {:handler (fn [req]
+                               (user/delete-user
+                                (assoc req :user-use-case user-use-case)))
+                     :parameters {:path [:map [:id :string]]
+                                :body [:map [:reason :string]]}
+                     :responses {204 {}
+                               400 {:body [:map [:error :string]]}
+                               403 {:body [:map [:error :string]]}
+                               404 {:body [:map [:error :string]]}
+                               500 {:body [:map [:error :string]]}}
+                     :summary "관리자가 사용자를 탈퇴 처리합니다"
+                     :description "관리자 권한으로 특정 사용자를 탈퇴 처리합니다."
+                     :swagger {:tags ["admin"]
+                             :security [{:bearer []}]}}}]})]) 

--- a/src/clj/kit/spooky_town/web/routes/admin.clj
+++ b/src/clj/kit/spooky_town/web/routes/admin.clj
@@ -1,6 +1,6 @@
 (ns kit.spooky-town.web.routes.admin
   (:require [kit.spooky-town.web.controllers.user :as user]
-            [kit.spooky-town.web.routes.api :refer [authenticated-route-data]]))
+            [kit.spooky-town.web.routes.common :refer [authenticated-route-data]]))
 
 (defn admin-routes [{:keys [user-use-case]}]
   ["/admin"

--- a/src/clj/kit/spooky_town/web/routes/api.clj
+++ b/src/clj/kit/spooky_town/web/routes/api.clj
@@ -7,6 +7,7 @@
    [kit.spooky-town.web.routes.health :refer [health-routes]]
    [kit.spooky-town.web.routes.auth :refer [auth-routes]]
    [kit.spooky-town.web.routes.user :refer [user-routes]]
+   [kit.spooky-town.web.routes.role-request :refer [role-request-routes]]
    [reitit.coercion.malli :as malli]
    [reitit.ring.coercion :as coercion]
    [reitit.ring.middleware.muuntaja :as muuntaja]
@@ -39,7 +40,8 @@
             :handler (swagger/create-swagger-handler)}}]
     (health-routes opts)
     (auth-routes opts)
-    (user-routes opts)]])
+    (user-routes opts)
+    (role-request-routes opts)]])
 
 (derive :reitit.routes/api :reitit/routes)
 

--- a/src/clj/kit/spooky_town/web/routes/api.clj
+++ b/src/clj/kit/spooky_town/web/routes/api.clj
@@ -84,6 +84,33 @@
                  :summary "새로운 사용자를 등록합니다"
                  :description "이메일, 이름, 비밀번호로 새로운 사용자를 등록합니다."
                  :swagger {:tags ["users"]}}}]
+     
+     ["/register"
+      ["/verify"
+       {:post {:handler (fn [req]
+                          (user/request-email-verification
+                           (assoc req :user-use-case user-use-case)))
+               :parameters {:body {:email string?}}
+               :responses {200 {:body {:message string?}}
+                           400 {:body {:error string?}}
+                           404 {:body {:error string?}}
+                           429 {:body {:error string?}}}
+               :summary "회원가입 이메일 인증 요청"
+               :description "회원가입을 위한 이메일 인증 링크를 발송합니다."
+               :swagger {:tags ["users"]}}}]
+      
+      ["/verify/confirm"
+       {:post {:handler (fn [req]
+                          (user/verify-email
+                           (assoc req :user-use-case user-use-case)))
+               :parameters {:body {:token string?}}
+               :responses {200 {:body {:message string?}}
+                           400 {:body {:error string?}}
+                           404 {:body {:error string?}}}
+               :summary "회원가입 이메일 인증 완료"
+               :description "이메일 인증 토큰을 확인하고 회원가입을 완료합니다."
+               :swagger {:tags ["users"]}}}]]
+     
      ["/:id/role"
       {:put {:handler (fn [req]
                         (user/update-user-role

--- a/src/clj/kit/spooky_town/web/routes/api.clj
+++ b/src/clj/kit/spooky_town/web/routes/api.clj
@@ -28,9 +28,6 @@
                 coercion/coerce-request-middleware
                 exception/wrap-exception]})
 
-(def authenticated-route-data
-  {:middleware [auth/wrap-auth-required]})
-
 (defn api-routes [opts]
   ["/api"
    route-data

--- a/src/clj/kit/spooky_town/web/routes/api.clj
+++ b/src/clj/kit/spooky_town/web/routes/api.clj
@@ -8,6 +8,7 @@
    [kit.spooky-town.web.routes.auth :refer [auth-routes]]
    [kit.spooky-town.web.routes.user :refer [user-routes]]
    [kit.spooky-town.web.routes.role-request :refer [role-request-routes]]
+   [kit.spooky-town.web.routes.admin :refer [admin-routes]]
    [reitit.coercion.malli :as malli]
    [reitit.ring.coercion :as coercion]
    [reitit.ring.middleware.muuntaja :as muuntaja]
@@ -41,7 +42,8 @@
     (health-routes opts)
     (auth-routes opts)
     (user-routes opts)
-    (role-request-routes opts)]])
+    (role-request-routes opts)
+    (admin-routes opts)]])
 
 (derive :reitit.routes/api :reitit/routes)
 

--- a/src/clj/kit/spooky_town/web/routes/api.clj
+++ b/src/clj/kit/spooky_town/web/routes/api.clj
@@ -26,8 +26,10 @@
                 muuntaja/format-request-middleware
                 coercion/coerce-response-middleware
                 coercion/coerce-request-middleware
-                exception/wrap-exception
-                auth/wrap-auth-required]})
+                exception/wrap-exception]})
+
+(def authenticated-route-data
+  {:middleware [auth/wrap-auth-required]})
 
 (defn api-routes [opts]
   ["/api"

--- a/src/clj/kit/spooky_town/web/routes/api.clj
+++ b/src/clj/kit/spooky_town/web/routes/api.clj
@@ -1,14 +1,12 @@
 (ns kit.spooky-town.web.routes.api
   (:require
-   [clojure.spec.alpha :as s]
    [integrant.core :as ig]
-   [kit.spooky-town.web.controllers.health :as health]
-   [kit.spooky-town.web.controllers.password :as password]
-   [kit.spooky-town.web.controllers.role-request :as role-request]
-   [kit.spooky-town.web.controllers.user :as user]
    [kit.spooky-town.web.middleware.auth :as auth]
    [kit.spooky-town.web.middleware.exception :as exception]
    [kit.spooky-town.web.middleware.formats :as formats]
+   [kit.spooky-town.web.routes.health :refer [health-routes]]
+   [kit.spooky-town.web.routes.auth :refer [auth-routes]]
+   [kit.spooky-town.web.routes.user :refer [user-routes]]
    [reitit.coercion.malli :as malli]
    [reitit.ring.coercion :as coercion]
    [reitit.ring.middleware.muuntaja :as muuntaja]
@@ -19,225 +17,29 @@
   {:coercion   malli/coercion
    :muuntaja   formats/instance
    :swagger    {:id ::api}
-   :middleware [;; query-params & form-params
-                parameters/parameters-middleware
-                  ;; content-negotiation
+   :middleware [parameters/parameters-middleware
                 muuntaja/format-negotiate-middleware
-                  ;; encoding response body
                 muuntaja/format-response-middleware
-                  ;; exception handling
                 coercion/coerce-exceptions-middleware
-                  ;; decoding request body
                 muuntaja/format-request-middleware
-                  ;; coercing response bodys
                 coercion/coerce-response-middleware
-                  ;; coercing request parameters
                 coercion/coerce-request-middleware
-                  ;; exception handling
                 exception/wrap-exception
-                  ;; authentication
                 auth/wrap-auth-required]})
 
-;; Routes
-(defn api-routes [{:keys [role-request-use-case user-use-case tx-manager] :as opts}]
+(defn api-routes [opts]
   ["/api"
    route-data
    ["/v1"
     ["/swagger.json"
      {:get {:no-doc true
             :swagger {:info {:title "kit.spooky-town API v1"
-                             :description "API for managing horror/thriller content"
-                             :version "1.0.0"}}
+                           :description "API for managing horror/thriller content"
+                           :version "1.0.0"}}
             :handler (swagger/create-swagger-handler)}}]
-    ["/health"
-     {:get {:handler (fn [req]
-                       (health/healthcheck! (assoc req :tx-manager tx-manager)))}}]
-
-    ["/auth"
-     ["/login"
-      {:post {:handler (fn [req]
-                         (user/authenticate
-                          (assoc req :user-use-case user-use-case)))
-              :parameters {:body {:email string?
-                                  :password string?}}
-              :responses {200 {:body {:token string?}}
-                          400 {:body {:error string?}}
-                          401 {:body {:error string?}}
-                          403 {:body {:error string?}}
-                          404 {:body {:error string?}}
-                          500 {:body {:error string?}}}
-              :summary "사용자 인증"
-              :description "이메일과 비밀번호로 사용자를 인증합니다."
-              :swagger {:tags ["auth"]}}}]]
-
-    ["/users"
-     ["" {:post {:handler (fn [req]
-                            (user/register
-                             (assoc req :user-use-case user-use-case)))
-                 :parameters {:body {:email string?
-                                     :name string?
-                                     :password string?}}
-                 :responses {201 {:body {:token string?}}
-                             400 {:body {:error string?}}
-                             409 {:body {:error string?}}
-                             500 {:body {:error string?}}}
-                 :summary "새로운 사용자를 등록합니다"
-                 :description "이메일, 이름, 비밀번호로 새로운 사용자를 등록합니다."
-                 :swagger {:tags ["users"]}}}]
-     
-     ["/register"
-      ["/verify"
-       {:post {:handler (fn [req]
-                          (user/request-email-verification
-                           (assoc req :user-use-case user-use-case)))
-               :parameters {:body {:email string?}}
-               :responses {200 {:body {:message string?}}
-                           400 {:body {:error string?}}
-                           404 {:body {:error string?}}
-                           429 {:body {:error string?}}}
-               :summary "회원가입 이메일 인증 요청"
-               :description "회원가입을 위한 이메일 인증 링크를 발송합니다."
-               :swagger {:tags ["users"]}}}]
-      
-      ["/verify/confirm"
-       {:post {:handler (fn [req]
-                          (user/verify-email
-                           (assoc req :user-use-case user-use-case)))
-               :parameters {:body {:token string?}}
-               :responses {200 {:body {:message string?}}
-                           400 {:body {:error string?}}
-                           404 {:body {:error string?}}}
-               :summary "회원가입 이메일 인증 완료"
-               :description "이메일 인증 토큰을 확인하고 회원가입을 완료합니다."
-               :swagger {:tags ["users"]}}}]]
-     
-     ["/:id/role"
-      {:put {:handler (fn [req]
-                        (user/update-user-role
-                         (-> req
-                             (assoc :user-use-case user-use-case)
-                             (assoc-in [:body-params :user-uuid] (get-in req [:path-params :id])))))
-             :parameters {:path {:id string?}
-                          :body {:role string?}}
-             :responses {200 {:body {:user-uuid string?
-                                     :roles #{string?}}}
-                         400 {:body {:error string?}}
-                         404 {:body {:error string?}}
-                         500 {:body {:error string?}}}
-             :summary "사용자 역할 업데이트"
-             :description "사용자의 역할을 업데이트합니다."
-             :swagger {:tags ["users"]
-                       :security [{:bearer []}]}}}]
-     ["/me"
-      ["/withdraw"
-       {:delete {:handler (fn [req]
-                            (user/withdraw
-                             (assoc req :user-use-case user-use-case)))
-                 :parameters {:body {:password string?
-                                     :reason (s/nilable string?)}}
-                 :responses {204 {}
-                             400 {:body {:error string?}}
-                             401 {:body {:error string?}}
-                             404 {:body {:error string?}}
-                             500 {:body {:error string?}}}
-                 :summary "회원 탈퇴"
-                 :description "비밀번호 확인 후 회원 탈퇴를 진행합니다."
-                 :swagger {:tags ["users"]
-                           :security [{:bearer []}]}}}]
-      ["/password/reset"
-       {:post {:handler (fn [req]
-                          (password/request-reset
-                           (assoc req :user-use-case user-use-case)))
-               :parameters {:body {:email string?}}
-               :responses {200 {:body {:token string?}}
-                           400 {:body {:error string?}}
-                           404 {:body {:error string?}}
-                           429 {:body {:error string?}}}
-               :summary "비밀번호 초기화 요청"
-               :description "이메일을 통해 비밀번호 초기화를 요청합니다."
-               :swagger {:tags ["users"]}}}]
-      ["/password/reset/confirm"
-       {:post {:handler (fn [req]
-                          (password/reset-password
-                           (assoc req :user-use-case user-use-case)))
-               :parameters {:body {:token string?
-                                   :new-password string?}}
-               :responses {200 {:body {:user-uuid string?}}
-                           400 {:body {:error string?}}
-                           401 {:body {:error string?}}
-                           404 {:body {:error string?}}}
-               :summary "비밀번호 초기화 완료"
-               :description "토큰을 사용하여 새로운 비밀번호로 변경합니다."
-               :swagger {:tags ["users"]}}}]]]
-    ["/role-requests"
-     {:post {:handler (fn [req]
-                        (role-request/create-request
-                         (assoc req :role-request-use-case role-request-use-case)))
-             :parameters {:body {:role string?
-                                 :reason string?}}
-             :responses {201 {:body {:message string?}}
-                         400 {:body {:error string?}}}
-             :summary "역할 변경 요청 생성"
-             :description "사용자가 새로운 역할로 변경을 요청합니다. 관리자 승인이 필요합니다."
-             :swagger {:tags ["role-requests"]
-                       :security [{:bearer []}]}}
-
-      :get {:handler (fn [req]
-                       (role-request/get-pending-requests
-                        (assoc req :role-request-use-case role-request-use-case)))
-            :responses {200 {:body [{:uuid string?
-                                     :user_id int?
-                                     :requested_role string?
-                                     :reason string?
-                                     :status string?
-                                     :created_at string?}]}
-                        403 {:body {:error string?}}}
-            :summary "대기 중인 역할 변경 요청 목록 조회"
-            :description "관리자가 승인 대기 중인 역할 변경 요청 목록을 조회합니다."
-            :swagger {:tags ["role-requests"]
-                      :security [{:bearer []}]}}}
-
-     ["/:id/approve"
-      {:put {:handler (fn [req]
-                        (role-request/approve-request
-                         (assoc req :role-request-use-case role-request-use-case)))
-             :parameters {:path {:id int?}}
-             :responses {200 {:body {:message string?}}
-                         400 {:body {:error string?}}
-                         403 {:body {:error string?}}}}}]
-
-     ["/:id/reject"
-      {:put {:handler (fn [req]
-                        (role-request/reject-request
-                         (assoc req :role-request-use-case role-request-use-case)))
-             :parameters {:path {:id int?}
-                          :body {:reason string?}}
-             :responses {200 {:body {:message string?}}
-                         400 {:body {:error string?}}
-                         403 {:body {:error string?}}}
-             :summary "역할 변경 요청 거절"
-             :description "관리자가 대기 중인 역할 변경 요청을 거절합니다."
-             :swagger {:tags ["role-requests"]
-                       :security [{:bearer []}]}}}]
-
-
-     ["/admin"
-      ["/users"
-       ["/:id"
-        {:delete {:handler (fn [req]
-                             (user/delete-user
-                              (assoc req :user-use-case user-use-case)))
-                  :parameters {:path {:id string?}
-                               :body {:reason string?}}
-                  :responses {204 {}
-                              400 {:body {:error string?}}
-                              403 {:body {:error string?}}
-                              404 {:body {:error string?}}
-                              500 {:body {:error string?}}}
-                  :summary "관리자가 사용자를 탈퇴 처리합니다"
-                  :description "관리자 권한으로 특정 사용자를 탈퇴 처리합니다."
-                  :swagger {:tags ["admin"]
-                            :security [{:bearer []}]}}}]]]]]])
+    (health-routes opts)
+    (auth-routes opts)
+    (user-routes opts)]])
 
 (derive :reitit.routes/api :reitit/routes)
 

--- a/src/clj/kit/spooky_town/web/routes/auth.clj
+++ b/src/clj/kit/spooky_town/web/routes/auth.clj
@@ -63,4 +63,35 @@
                          404 {:body [:map [:error :string]]}}
              :summary "회원가입 이메일 인증 완료"
              :description "이메일 인증 토큰을 확인하고 회원가입을 완료합니다."
-             :swagger {:tags ["auth"]}}}]]])
+             :swagger {:tags ["auth"]}}}]
+
+    ["/password"
+     ["/reset"
+      {:post {:handler (fn [req]
+                         (password/request-reset
+                          (assoc req :user-use-case user-use-case)))
+              :parameters {:body [:map
+                                  [:email :string]]}
+              :responses {200 {:body [:map [:token :string]]}
+                          400 {:body [:map [:error :string]]}
+                          404 {:body [:map [:error :string]]}
+                          429 {:body [:map [:error :string]]}}
+              :summary "비밀번호 초기화 요청"
+              :description "이메일을 통해 비밀번호 초기화를 요청합니다."
+              :swagger {:tags ["auth"]}}}]
+
+     ["/reset/confirm"
+      {:post {:handler (fn [req]
+                         (password/reset-password
+                          (assoc req :user-use-case user-use-case)))
+              :parameters {:body [:map
+                                  [:token :string]
+                                  [:new-password :string]]}
+              :responses {200 {:body [:map [:user-uuid :string]]}
+                          400 {:body [:map [:error :string]]}
+                          401 {:body [:map [:error :string]]}
+                          404 {:body [:map [:error :string]]}}
+              :summary "비밀번호 초기화 완료"
+              :description "토큰을 사용하여 새로운 비밀번호로 변경합니다."
+              :swagger {:tags ["auth"]}}}]]
+              ]])

--- a/src/clj/kit/spooky_town/web/routes/auth.clj
+++ b/src/clj/kit/spooky_town/web/routes/auth.clj
@@ -1,37 +1,66 @@
 (ns kit.spooky-town.web.routes.auth
-  (:require [kit.spooky-town.web.controllers.user :as user]))
+  (:require [kit.spooky-town.web.controllers.user :as user]
+            [kit.spooky-town.web.controllers.password :as password]))
 
 (defn auth-routes [{:keys [user-use-case]}]
   ["/auth"
    ["/login"
     {:post {:handler (fn [req]
-                      (user/authenticate
-                       (assoc req :user-use-case user-use-case)))
+                       (user/authenticate
+                        (assoc req :user-use-case user-use-case)))
             :parameters {:body [:map
-                              [:email :string]
-                              [:password :string]]}
+                                [:email :string]
+                                [:password :string]]}
             :responses {200 {:body [:map [:token :string]]}
-                       400 {:body [:map [:error :string]]}
-                       401 {:body [:map [:error :string]]}
-                       403 {:body [:map [:error :string]]}
-                       404 {:body [:map [:error :string]]}
-                       500 {:body [:map [:error :string]]}}
+                        400 {:body [:map [:error :string]]}
+                        401 {:body [:map [:error :string]]}
+                        403 {:body [:map [:error :string]]}
+                        404 {:body [:map [:error :string]]}
+                        500 {:body [:map [:error :string]]}}
             :summary "사용자 인증"
             :description "이메일과 비밀번호로 사용자를 인증합니다."
             :swagger {:tags ["auth"]}}}]
-   
+
    ["/register"
-    {:post {:handler (fn [req]
-                      (user/register
-                       (assoc req :user-use-case user-use-case)))
-            :parameters {:body [:map
-                              [:email :string]
-                              [:name :string]
-                              [:password :string]]}
-            :responses {201 {:body [:map [:token :string]]}
-                       400 {:body [:map [:error :string]]}
-                       409 {:body [:map [:error :string]]}
-                       500 {:body [:map [:error :string]]}}
-            :summary "새로운 사용자를 등록합니다"
-            :description "이메일, 이름, 비밀번호로 새로운 사용자를 등록합니다."
-            :swagger {:tags ["auth"]}}}]]) 
+    [""
+     {:post {:handler (fn [req]
+                        (user/register
+                         (assoc req :user-use-case user-use-case)))
+             :parameters {:body [:map
+                                 [:email :string]
+                                 [:name :string]
+                                 [:password :string]]}
+             :responses {201 {:body [:map [:token :string]]}
+                         400 {:body [:map [:error :string]]}
+                         409 {:body [:map [:error :string]]}
+                         500 {:body [:map [:error :string]]}}
+             :summary "새로운 사용자를 등록합니다"
+             :description "이메일, 이름, 비밀번호로 새로운 사용자를 등록합니다."
+             :swagger {:tags ["auth"]}}}]
+
+    ["/verify"
+     {:post {:handler (fn [req]
+                        (user/request-email-verification
+                         (assoc req :user-use-case user-use-case)))
+             :parameters {:body [:map
+                                 [:email :string]]}
+             :responses {200 {:body [:map [:message :string]]}
+                         400 {:body [:map [:error :string]]}
+                         404 {:body [:map [:error :string]]}
+                         429 {:body [:map [:error :string]]}}
+             :summary "회원가입 이메일 인증 요청"
+             :description "회원가입을 위한 이메일 인증 링크를 발송합니다."
+             :swagger {:tags ["auth"]}}}]
+
+    ["/verify/confirm"
+     {:post {:handler (fn [req]
+                        (user/verify-email
+                         (assoc req :user-use-case user-use-case)))
+             :parameters {:body [:map
+                                 [:token :string]]}
+             :responses {200 {:body [:map [:message :string]]}
+                         400 {:body [:map [:error :string]]}
+                         404 {:body [:map [:error :string]]}}
+             :summary "회원가입 이메일 인증 완료"
+             :description "이메일 인증 토큰을 확인하고 회원가입을 완료합니다."
+             :swagger {:tags ["auth"]}}}]]])

--- a/src/clj/kit/spooky_town/web/routes/auth.clj
+++ b/src/clj/kit/spooky_town/web/routes/auth.clj
@@ -1,0 +1,37 @@
+(ns kit.spooky-town.web.routes.auth
+  (:require [kit.spooky-town.web.controllers.user :as user]))
+
+(defn auth-routes [{:keys [user-use-case]}]
+  ["/auth"
+   ["/login"
+    {:post {:handler (fn [req]
+                      (user/authenticate
+                       (assoc req :user-use-case user-use-case)))
+            :parameters {:body [:map
+                              [:email :string]
+                              [:password :string]]}
+            :responses {200 {:body [:map [:token :string]]}
+                       400 {:body [:map [:error :string]]}
+                       401 {:body [:map [:error :string]]}
+                       403 {:body [:map [:error :string]]}
+                       404 {:body [:map [:error :string]]}
+                       500 {:body [:map [:error :string]]}}
+            :summary "사용자 인증"
+            :description "이메일과 비밀번호로 사용자를 인증합니다."
+            :swagger {:tags ["auth"]}}}]
+   
+   ["/register"
+    {:post {:handler (fn [req]
+                      (user/register
+                       (assoc req :user-use-case user-use-case)))
+            :parameters {:body [:map
+                              [:email :string]
+                              [:name :string]
+                              [:password :string]]}
+            :responses {201 {:body [:map [:token :string]]}
+                       400 {:body [:map [:error :string]]}
+                       409 {:body [:map [:error :string]]}
+                       500 {:body [:map [:error :string]]}}
+            :summary "새로운 사용자를 등록합니다"
+            :description "이메일, 이름, 비밀번호로 새로운 사용자를 등록합니다."
+            :swagger {:tags ["auth"]}}}]]) 

--- a/src/clj/kit/spooky_town/web/routes/common.clj
+++ b/src/clj/kit/spooky_town/web/routes/common.clj
@@ -1,0 +1,5 @@
+(ns kit.spooky-town.web.routes.common
+  (:require [kit.spooky-town.web.middleware.auth :as auth]))
+
+(def authenticated-route-data
+  {:middleware [auth/wrap-auth-required]}) 

--- a/src/clj/kit/spooky_town/web/routes/health.clj
+++ b/src/clj/kit/spooky_town/web/routes/health.clj
@@ -1,0 +1,7 @@
+(ns kit.spooky-town.web.routes.health
+  (:require [kit.spooky-town.web.controllers.health :as health]))
+
+(defn health-routes [opts]
+  ["/health"
+   {:get {:handler (fn [req]
+                    (health/healthcheck! (assoc req :tx-manager (:tx-manager opts))))}}]) 

--- a/src/clj/kit/spooky_town/web/routes/role_request.clj
+++ b/src/clj/kit/spooky_town/web/routes/role_request.clj
@@ -1,0 +1,62 @@
+(ns kit.spooky-town.web.routes.role-request
+  (:require [kit.spooky-town.web.controllers.role-request :as role-request]))
+
+(defn role-request-routes [{:keys [role-request-use-case]}]
+  ["/role-requests"
+   ["" 
+    {:post {:handler (fn [req]
+                      (role-request/create-request
+                       (assoc req :role-request-use-case role-request-use-case)))
+            :parameters {:body [:map
+                              [:role :string]
+                              [:reason :string]]}
+            :responses {201 {:body [:map [:message :string]]}
+                       400 {:body [:map [:error :string]]}}
+            :summary "역할 변경 요청 생성"
+            :description "사용자가 새로운 역할로 변경을 요청합니다. 관리자 승인이 필요합니다."
+            :swagger {:tags ["role-requests"]
+                     :security [{:bearer []}]}}
+
+     :get {:handler (fn [req]
+                     (role-request/get-pending-requests
+                      (assoc req :role-request-use-case role-request-use-case)))
+           :responses {200 {:body [:vector
+                                 [:map
+                                  [:uuid :string]
+                                  [:user_id :int]
+                                  [:requested_role :string]
+                                  [:reason :string]
+                                  [:status :string]
+                                  [:created_at :string]]]}
+                      403 {:body [:map [:error :string]]}}
+           :summary "대기 중인 역할 변경 요청 목록 조회"
+           :description "관리자가 승인 대기 중인 역할 변경 요청 목록을 조회합니다."
+           :swagger {:tags ["role-requests"]
+                    :security [{:bearer []}]}}}]
+
+   ["/:id/approve"
+    {:put {:handler (fn [req]
+                     (role-request/approve-request
+                      (assoc req :role-request-use-case role-request-use-case)))
+           :parameters {:path [:map [:id :int]]}
+           :responses {200 {:body [:map [:message :string]]}
+                      400 {:body [:map [:error :string]]}
+                      403 {:body [:map [:error :string]]}}
+           :summary "역할 변경 요청 승인"
+           :description "관리자가 대기 중인 역할 변경 요청을 승인합니다."
+           :swagger {:tags ["role-requests"]
+                    :security [{:bearer []}]}}}]
+
+   ["/:id/reject"
+    {:put {:handler (fn [req]
+                     (role-request/reject-request
+                      (assoc req :role-request-use-case role-request-use-case)))
+           :parameters {:path [:map [:id :int]]
+                       :body [:map [:reason :string]]}
+           :responses {200 {:body [:map [:message :string]]}
+                      400 {:body [:map [:error :string]]}
+                      403 {:body [:map [:error :string]]}}
+           :summary "역할 변경 요청 거절"
+           :description "관리자가 대기 중인 역할 변경 요청을 거절합니다."
+           :swagger {:tags ["role-requests"]
+                    :security [{:bearer []}]}}}]]) 

--- a/src/clj/kit/spooky_town/web/routes/role_request.clj
+++ b/src/clj/kit/spooky_town/web/routes/role_request.clj
@@ -1,62 +1,64 @@
 (ns kit.spooky-town.web.routes.role-request
-  (:require [kit.spooky-town.web.controllers.role-request :as role-request]))
+  (:require [kit.spooky-town.web.controllers.role-request :as role-request]
+            [kit.spooky-town.web.routes.api :refer [authenticated-route-data]]))
 
 (defn role-request-routes [{:keys [role-request-use-case]}]
   ["/role-requests"
-   ["" 
-    {:post {:handler (fn [req]
-                      (role-request/create-request
-                       (assoc req :role-request-use-case role-request-use-case)))
-            :parameters {:body [:map
-                              [:role :string]
-                              [:reason :string]]}
-            :responses {201 {:body [:map [:message :string]]}
-                       400 {:body [:map [:error :string]]}}
-            :summary "역할 변경 요청 생성"
-            :description "사용자가 새로운 역할로 변경을 요청합니다. 관리자 승인이 필요합니다."
-            :swagger {:tags ["role-requests"]
-                     :security [{:bearer []}]}}
+   (merge authenticated-route-data
+          {""  ;; 모든 role-requests 엔드포인트는 인증 필요
+           {:post {:handler (fn [req]
+                            (role-request/create-request
+                             (assoc req :role-request-use-case role-request-use-case)))
+                  :parameters {:body [:map
+                                    [:role :string]
+                                    [:reason :string]]}
+                  :responses {201 {:body [:map [:message :string]]}
+                             400 {:body [:map [:error :string]]}}
+                  :summary "역할 변경 요청 생성"
+                  :description "사용자가 새로운 역할로 변경을 요청합니다. 관리자 승인이 필요합니다."
+                  :swagger {:tags ["role-requests"]
+                          :security [{:bearer []}]}}
 
-     :get {:handler (fn [req]
-                     (role-request/get-pending-requests
-                      (assoc req :role-request-use-case role-request-use-case)))
-           :responses {200 {:body [:vector
-                                 [:map
-                                  [:uuid :string]
-                                  [:user_id :int]
-                                  [:requested_role :string]
-                                  [:reason :string]
-                                  [:status :string]
-                                  [:created_at :string]]]}
-                      403 {:body [:map [:error :string]]}}
-           :summary "대기 중인 역할 변경 요청 목록 조회"
-           :description "관리자가 승인 대기 중인 역할 변경 요청 목록을 조회합니다."
-           :swagger {:tags ["role-requests"]
-                    :security [{:bearer []}]}}}]
+            :get {:handler (fn [req]
+                           (role-request/get-pending-requests
+                            (assoc req :role-request-use-case role-request-use-case)))
+                 :responses {200 {:body [:vector
+                                      [:map
+                                       [:uuid :string]
+                                       [:user_id :int]
+                                       [:requested_role :string]
+                                       [:reason :string]
+                                       [:status :string]
+                                       [:created_at :string]]]}
+                          403 {:body [:map [:error :string]]}}
+                 :summary "대기 중인 역할 변경 요청 목록 조회"
+                 :description "관리자가 승인 대기 중인 역할 변경 요청 목록을 조회합니다."
+                 :swagger {:tags ["role-requests"]
+                          :security [{:bearer []}]}}}
 
-   ["/:id/approve"
-    {:put {:handler (fn [req]
-                     (role-request/approve-request
-                      (assoc req :role-request-use-case role-request-use-case)))
-           :parameters {:path [:map [:id :int]]}
-           :responses {200 {:body [:map [:message :string]]}
-                      400 {:body [:map [:error :string]]}
-                      403 {:body [:map [:error :string]]}}
-           :summary "역할 변경 요청 승인"
-           :description "관리자가 대기 중인 역할 변경 요청을 승인합니다."
-           :swagger {:tags ["role-requests"]
-                    :security [{:bearer []}]}}}]
+           "/:id/approve"
+           {:put {:handler (fn [req]
+                           (role-request/approve-request
+                            (assoc req :role-request-use-case role-request-use-case)))
+                 :parameters {:path [:map [:id :int]]}
+                 :responses {200 {:body [:map [:message :string]]}
+                           400 {:body [:map [:error :string]]}
+                           403 {:body [:map [:error :string]]}}
+                 :summary "역할 변경 요청 승인"
+                 :description "관리자가 대기 중인 역할 변경 요청을 승인합니다."
+                 :swagger {:tags ["role-requests"]
+                          :security [{:bearer []}]}}}
 
-   ["/:id/reject"
-    {:put {:handler (fn [req]
-                     (role-request/reject-request
-                      (assoc req :role-request-use-case role-request-use-case)))
-           :parameters {:path [:map [:id :int]]
-                       :body [:map [:reason :string]]}
-           :responses {200 {:body [:map [:message :string]]}
-                      400 {:body [:map [:error :string]]}
-                      403 {:body [:map [:error :string]]}}
-           :summary "역할 변경 요청 거절"
-           :description "관리자가 대기 중인 역할 변경 요청을 거절합니다."
-           :swagger {:tags ["role-requests"]
-                    :security [{:bearer []}]}}}]]) 
+           "/:id/reject"
+           {:put {:handler (fn [req]
+                           (role-request/reject-request
+                            (assoc req :role-request-use-case role-request-use-case)))
+                 :parameters {:path [:map [:id :int]]
+                            :body [:map [:reason :string]]}
+                 :responses {200 {:body [:map [:message :string]]}
+                           400 {:body [:map [:error :string]]}
+                           403 {:body [:map [:error :string]]}}
+                 :summary "역할 변경 요청 거절"
+                 :description "관리자가 대기 중인 역할 변경 요청을 거절합니다."
+                 :swagger {:tags ["role-requests"]
+                          :security [{:bearer []}]}}}})]) 

--- a/src/clj/kit/spooky_town/web/routes/role_request.clj
+++ b/src/clj/kit/spooky_town/web/routes/role_request.clj
@@ -1,6 +1,6 @@
 (ns kit.spooky-town.web.routes.role-request
   (:require [kit.spooky-town.web.controllers.role-request :as role-request]
-            [kit.spooky-town.web.routes.api :refer [authenticated-route-data]]))
+            [kit.spooky-town.web.routes.common :refer [authenticated-route-data]]))
 
 (defn role-request-routes [{:keys [role-request-use-case]}]
   ["/role-requests"

--- a/src/clj/kit/spooky_town/web/routes/user.clj
+++ b/src/clj/kit/spooky_town/web/routes/user.clj
@@ -1,45 +1,48 @@
 (ns kit.spooky-town.web.routes.user
-  (:require [kit.spooky-town.web.controllers.user :as user]))
+  (:require [kit.spooky-town.web.controllers.user :as user]
+            [kit.spooky-town.web.routes.api :refer [authenticated-route-data]]))
 
 (defn user-routes [{:keys [user-use-case]}]
   ["/users"
    ["/:id/role"  ;; 사용자 역할 업데이트
-    {:put {:handler (fn [req]
-                     (user/update-user-role
-                      (-> req
-                          (assoc :user-use-case user-use-case)
-                          (assoc-in [:body-params :user-uuid] 
-                                  (get-in req [:path-params :id])))))
-           :parameters {:path [:map 
-                             [:id :string]]
-                      :body [:map 
-                            [:role :string]]}
-           :responses {200 {:body [:map 
-                                 [:user-uuid :string]
-                                 [:roles [:set :string]]]}
-                      400 {:body [:map [:error :string]]}
-                      404 {:body [:map [:error :string]]}
-                      500 {:body [:map [:error :string]]}}
-           :summary "사용자 역할 업데이트"
-           :description "사용자의 역할을 업데이트합니다."
-           :swagger {:tags ["users"]
-                    :security [{:bearer []}]}}}]
+    (merge authenticated-route-data
+           {:put {:handler (fn [req]
+                           (user/update-user-role
+                            (-> req
+                                (assoc :user-use-case user-use-case)
+                                (assoc-in [:body-params :user-uuid] 
+                                        (get-in req [:path-params :id])))))
+                  :parameters {:path [:map 
+                                   [:id :string]]
+                             :body [:map 
+                                   [:role :string]]}
+                  :responses {200 {:body [:map 
+                                       [:user-uuid :string]
+                                       [:roles [:set :string]]]}
+                            400 {:body [:map [:error :string]]}
+                            404 {:body [:map [:error :string]]}
+                            500 {:body [:map [:error :string]]}}
+                  :summary "사용자 역할 업데이트"
+                  :description "사용자의 역할을 업데이트합니다."
+                  :swagger {:tags ["users"]
+                          :security [{:bearer []}]}}})]
    
    ["/me"  ;; 회원 탈퇴
     ["/withdraw"
-     {:delete {:handler (fn [req]
-                         (user/withdraw
-                          (assoc req :user-use-case user-use-case)))
-               :parameters {:body [:map
-                                 [:password :string]
-                                 [:reason {:optional true} :string]]}
-               :responses {204 {}
-                         400 {:body [:map [:error :string]]}
-                         401 {:body [:map [:error :string]]}
-                         404 {:body [:map [:error :string]]}
-                         500 {:body [:map [:error :string]]}}
-               :summary "회원 탈퇴"
-               :description "비밀번호 확인 후 회원 탈퇴를 진행합니다."
-               :swagger {:tags ["users"]
-                        :security [{:bearer []}]}}}]]])
+     (merge authenticated-route-data
+            {:delete {:handler (fn [req]
+                               (user/withdraw
+                                (assoc req :user-use-case user-use-case)))
+                     :parameters {:body [:map
+                                      [:password :string]
+                                      [:reason {:optional true} :string]]}
+                     :responses {204 {}
+                               400 {:body [:map [:error :string]]}
+                               401 {:body [:map [:error :string]]}
+                               404 {:body [:map [:error :string]]}
+                               500 {:body [:map [:error :string]]}}
+                     :summary "회원 탈퇴"
+                     :description "비밀번호 확인 후 회원 탈퇴를 진행합니다."
+                     :swagger {:tags ["users"]
+                             :security [{:bearer []}]}}})]]])
  

--- a/src/clj/kit/spooky_town/web/routes/user.clj
+++ b/src/clj/kit/spooky_town/web/routes/user.clj
@@ -1,6 +1,6 @@
 (ns kit.spooky-town.web.routes.user
   (:require [kit.spooky-town.web.controllers.user :as user]
-            [kit.spooky-town.web.routes.api :refer [authenticated-route-data]]))
+            [kit.spooky-town.web.routes.common :refer [authenticated-route-data]]))
 
 (defn user-routes [{:keys [user-use-case]}]
   ["/users"

--- a/src/clj/kit/spooky_town/web/routes/user.clj
+++ b/src/clj/kit/spooky_town/web/routes/user.clj
@@ -1,7 +1,45 @@
 (ns kit.spooky-town.web.routes.user
-  (:require [kit.spooky-town.web.controllers.user :as user]
-            [kit.spooky-town.web.controllers.password :as password]))
+  (:require [kit.spooky-town.web.controllers.user :as user]))
 
 (defn user-routes [{:keys [user-use-case]}]
-  ["/users"])  ;; 사용자 관리 기능을 여기에 추가할 예정
+  ["/users"
+   ["/:id/role"  ;; 사용자 역할 업데이트
+    {:put {:handler (fn [req]
+                     (user/update-user-role
+                      (-> req
+                          (assoc :user-use-case user-use-case)
+                          (assoc-in [:body-params :user-uuid] 
+                                  (get-in req [:path-params :id])))))
+           :parameters {:path [:map 
+                             [:id :string]]
+                      :body [:map 
+                            [:role :string]]}
+           :responses {200 {:body [:map 
+                                 [:user-uuid :string]
+                                 [:roles [:set :string]]]}
+                      400 {:body [:map [:error :string]]}
+                      404 {:body [:map [:error :string]]}
+                      500 {:body [:map [:error :string]]}}
+           :summary "사용자 역할 업데이트"
+           :description "사용자의 역할을 업데이트합니다."
+           :swagger {:tags ["users"]
+                    :security [{:bearer []}]}}}]
+   
+   ["/me"  ;; 회원 탈퇴
+    ["/withdraw"
+     {:delete {:handler (fn [req]
+                         (user/withdraw
+                          (assoc req :user-use-case user-use-case)))
+               :parameters {:body [:map
+                                 [:password :string]
+                                 [:reason {:optional true} :string]]}
+               :responses {204 {}
+                         400 {:body [:map [:error :string]]}
+                         401 {:body [:map [:error :string]]}
+                         404 {:body [:map [:error :string]]}
+                         500 {:body [:map [:error :string]]}}
+               :summary "회원 탈퇴"
+               :description "비밀번호 확인 후 회원 탈퇴를 진행합니다."
+               :swagger {:tags ["users"]
+                        :security [{:bearer []}]}}}]]])
  

--- a/src/clj/kit/spooky_town/web/routes/user.clj
+++ b/src/clj/kit/spooky_town/web/routes/user.clj
@@ -1,0 +1,7 @@
+(ns kit.spooky-town.web.routes.user
+  (:require [kit.spooky-town.web.controllers.user :as user]
+            [kit.spooky-town.web.controllers.password :as password]))
+
+(defn user-routes [{:keys [user-use-case]}]
+  ["/users"])  ;; 사용자 관리 기능을 여기에 추가할 예정
+ 

--- a/test/clj/kit/spooky_town/domain/user/test/email_gateway_fixture.clj
+++ b/test/clj/kit/spooky_town/domain/user/test/email_gateway_fixture.clj
@@ -1,0 +1,18 @@
+(ns kit.spooky-town.domain.user.test.email-gateway-fixture
+  (:require [kit.spooky-town.domain.user.gateway.email :as email-gateway]))
+
+(defn send-verification-email [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn send-password-reset-email [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+
+(defn send-email-change-verification [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestEmailGateway []
+  email-gateway/EmailGateway
+  (send-verification-email [this email purpose] (send-verification-email this email purpose))
+  (send-password-reset-email [this email purpose] (send-password-reset-email this email purpose))
+  (send-email-change-verification [this email purpose] (send-email-change-verification this email purpose)))

--- a/test/clj/kit/spooky_town/domain/user/test/email_token_gateway_fixture.clj
+++ b/test/clj/kit/spooky_town/domain/user/test/email_token_gateway_fixture.clj
@@ -1,0 +1,13 @@
+(ns kit.spooky-town.domain.user.test.email-token-gateway-fixture
+  (:require [kit.spooky-town.domain.user.gateway.email-token :as email-token-gateway]))
+
+(defn generate-token [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn verify-token [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestEmailTokenGateway []
+  email-token-gateway/EmailTokenGateway
+  (generate-token [this email purpose] (generate-token this email purpose))
+  (verify-token [this token] (verify-token this token)))

--- a/test/clj/kit/spooky_town/domain/user/test/email_verification_gateway_fixture.clj
+++ b/test/clj/kit/spooky_town/domain/user/test/email_verification_gateway_fixture.clj
@@ -1,0 +1,22 @@
+(ns kit.spooky-town.domain.user.test.email-verification-gateway-fixture
+  (:require [kit.spooky-town.domain.user.gateway.email-verification :as email-verification-gateway]))
+
+(defn save-verification-status! [_ _ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn get-verification-status [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn has-verified? [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestEmailVerificationGateway []
+  email-verification-gateway/EmailVerificationGateway
+  (save-verification-status! [this email purpose status] 
+    (save-verification-status! this email purpose status))
+  
+  (get-verification-status [this email purpose]
+    (get-verification-status this email purpose))
+  
+  (has-verified? [this email purpose]
+    (has-verified? this email purpose))) 

--- a/test/clj/kit/spooky_town/domain/user/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/user/use_case_test.clj
@@ -7,7 +7,10 @@
             [kit.spooky-town.domain.user.test.repository :as user-repository-fixture :refer [->TestUserRepository]]
             [kit.spooky-town.domain.event.test.subscriber :as event-subscriber-fixture :refer [->TestEventSubscriber]]
             [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
-            [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
+            [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer 
+             [->TestEmailTokenGateway]]
+            [kit.spooky-town.domain.user.test.email-verification-gateway-fixture :as email-verification-gateway-fixture :refer 
+             [->TestEmailVerificationGateway]]
             [kit.spooky-town.domain.event :as event]))
 
 (deftest register-user-test
@@ -18,7 +21,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)]
 
     (testing "유효한 데이터로 사용자 등록"
       (with-redefs [password-gateway-fixture/hash-password (fn [_ password] "hashed_password")
@@ -51,7 +55,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)]
 
     (testing "유효한 자격 증명으로 인증"
       (with-redefs [user-repository-fixture/find-by-email 
@@ -108,7 +113,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway) 
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"]
 
     (testing "유효한 데이터로 사용자 정보 업데이트"
@@ -176,7 +182,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         admin-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         user-uuid #uuid "660e8400-e29b-41d4-a716-446655440000"]
 
@@ -266,7 +273,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"]
 
     (testing "유효한 비밀번호로 회원 탈퇴"
@@ -292,7 +300,7 @@
           (is (f/failed? result))
           (is (= :withdrawal-error/user-not-found (f/message result))))))
 
-    (testing "이미 탈퇴한 사용자"
+    (testing "이미 탈퇴한 용자"
       (with-redefs [user-repository-fixture/find-by-uuid
                     (fn [_ _] 
                       {:uuid test-uuid
@@ -325,7 +333,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         admin-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         user-uuid #uuid "660e8400-e29b-41d4-a716-446655440000"]
 
@@ -410,7 +419,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         test-email "test@example.com"]
 
@@ -478,28 +488,61 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx 
+                                        password-gateway 
+                                        token-gateway 
+                                        user-repository 
+                                        event-subscriber 
+                                        email-gateway 
+                                        email-token-gateway
+                                        email-verification-gateway)]
 
-    (testing "이메일 인증 요청 - 유효한 목적"
-      (with-redefs [email-token-gateway-fixture/generate-token (fn [_ _ _] "test-token")
-                    email-gateway-fixture/send-verification-email (fn [_ _ _] true)]
-        (let [result (use-case/request-email-verification user-use-case "test@example.com" :registration)]
-          (is (= {:token "test-token"} result)))))
+    (testing "이메일 인증 상태 확인 - 인증된 이메일"
+      (with-redefs [email-verification-gateway-fixture/get-verification-status 
+                    (fn [_ _ _] 
+                      {:status :verified
+                       :verified-at (java.util.Date.)})]
+        (let [result (use-case/check-email-verification-status 
+                      user-use-case 
+                      "test@example.com")]
+          (is (f/ok? result))
+          (is (= :verified (get-in result [:status :status]))))))
 
-    (testing "이메일 인증 요청 - 잘못된 목적"
-      (let [result (use-case/request-email-verification user-use-case "test@example.com" :invalid-purpose)]
+    (testing "이메일 인증 상태 확인 - 인증되지 않은 이메일"
+      (with-redefs [email-verification-gateway-fixture/get-verification-status 
+                    (fn [_ _ _] nil)]
+        (let [result (use-case/check-email-verification-status 
+                      user-use-case 
+                      "test@example.com")]
+          (is (f/failed? result))
+          (is (= :email-verification/not-verified (f/message result))))))
+
+    (testing "이메일 인증 상태 확인 - 빈 이메일"
+      (let [result (use-case/check-email-verification-status user-use-case "")]
         (is (f/failed? result))
-        (is (= :email-verification/invalid-purpose (f/message result)))))
+        (is (= :email-verification/invalid-email (f/message result)))))
 
-    (testing "이메일 검증 - 유효한 토큰"
+    (testing "이메일 인증 완료 - 성공"
       (with-redefs [email-token-gateway-fixture/verify-token 
-                    (fn [_ _] {:email "test@example.com" :purpose :registration})]
+                    (fn [_ _] 
+                      {:email "test@example.com" 
+                       :purpose :registration})
+                    email-verification-gateway-fixture/save-verification-status!
+                    (fn [_ _ _ _] true)]
         (let [result (use-case/verify-email user-use-case "valid-token")]
-          (is (= {:email "test@example.com" :purpose :registration} result)))))
+          (is (f/ok? result))
+          (is (= "test@example.com" (:email result)))
+          (is (= :registration (:purpose result))))))
 
-    (testing "이메일 검증 - 잘못된 토큰"
+    (testing "이메일 인증 완료 - 실패 (저장 실패)"
       (with-redefs [email-token-gateway-fixture/verify-token 
-                    (fn [_ _] (f/fail :invalid-token))]
-        (let [result (use-case/verify-email user-use-case "invalid-token")]
+                    (fn [_ _] 
+                      {:email "test@example.com" 
+                       :purpose :registration})
+                    email-verification-gateway-fixture/save-verification-status!
+                    (fn [_ _ _ _] 
+                      (f/fail :email-verification/save-failed))]
+        (let [result (use-case/verify-email user-use-case "valid-token")]
           (is (f/failed? result))
           (is (= :email-verification/invalid-token (f/message result))))))))

--- a/test/clj/kit/spooky_town/infrastructure/auth/jwt_email_token_gateway_test.clj
+++ b/test/clj/kit/spooky_town/infrastructure/auth/jwt_email_token_gateway_test.clj
@@ -1,0 +1,24 @@
+(ns kit.spooky-town.infrastructure.auth.jwt-email-token-gateway-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.infrastructure.auth.jwt-email-token-gateway :as jwt]
+            [kit.spooky-town.domain.user.gateway.email-token :as email-token-gateway]
+            [failjure.core :as f]))
+
+(deftest jwt-email-token-gateway-test
+  (let [test-secret "test-secret"
+        gateway (jwt/->JWTEmailTokenGateway test-secret)]
+    
+    (testing "토큰 생성 및 검증"
+      (let [email "test@example.com"
+            purpose :registration
+            token (email-token-gateway/generate-token gateway email purpose)
+            result (email-token-gateway/verify-token gateway token)]
+        (is (string? token))
+        (is (f/ok? result))
+        (is (= email (:email result)))
+        (is (= purpose (:purpose result)))))
+    
+    (testing "잘못된 토큰 검증"
+      (let [result (email-token-gateway/verify-token gateway "invalid-token")]
+        (is (f/failed? result))
+        (is (= :invalid-token (f/message result))))))) 

--- a/test/clj/kit/spooky_town/infrastructure/email/smtp_gateway_test.clj
+++ b/test/clj/kit/spooky_town/infrastructure/email/smtp_gateway_test.clj
@@ -1,0 +1,23 @@
+(ns kit.spooky-town.infrastructure.email.smtp-gateway-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.infrastructure.email.smtp-gateway :as smtp]
+            [kit.spooky-town.domain.user.gateway.email :as email-gateway]
+            [postal.core :as postal]))
+
+(deftest smtp-email-gateway-test
+  (let [sent-emails (atom [])
+        test-smtp-config {:host "test-smtp.example.com"
+                         :port 587
+                         :user "test@example.com"
+                         :pass "test-password"
+                         :from "noreply@example.com"}
+        test-base-url "http://test.example.com"
+        gateway (smtp/->SMTPEmailGateway test-smtp-config test-base-url)]
+    
+    (testing "회원가입 인증 이메일 발송"
+      (with-redefs [postal/send-message (fn [_ msg] (swap! sent-emails conj msg) {:code 0})]
+        (email-gateway/send-verification-email gateway "user@example.com" "test-token")
+        (let [sent-email (last @sent-emails)]
+          (is (= "user@example.com" (:to sent-email)))
+          (is (= "스푸키 타운 회원가입 인증" (:subject sent-email)))
+          (is (re-find #"test-token" (get-in sent-email [:body 1 :html])))))))) 

--- a/test/clj/kit/spooky_town/web/controllers/password_test.clj
+++ b/test/clj/kit/spooky_town/web/controllers/password_test.clj
@@ -9,6 +9,7 @@
    [kit.spooky-town.domain.user.use-case :refer [->UserUseCaseImpl]]
    [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
    [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
+   [kit.spooky-town.domain.user.test.email-verification-gateway-fixture :as email-verification-gateway-fixture :refer [->TestEmailVerificationGateway]]
    [kit.spooky-town.web.controllers.password :as password]))
 
 (deftest request-password-reset-test
@@ -19,7 +20,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         test-email "test@example.com"
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"]
 
@@ -101,7 +103,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"]
 
     (testing "비밀번호 초기화 - 성공"

--- a/test/clj/kit/spooky_town/web/controllers/password_test.clj
+++ b/test/clj/kit/spooky_town/web/controllers/password_test.clj
@@ -7,6 +7,8 @@
    [kit.spooky-town.domain.user.test.repository :as user-repository-fixture :refer [->TestUserRepository]]
    [kit.spooky-town.domain.user.test.token-gateway :as token-gateway-fixture :refer [->TestTokenGateway]]
    [kit.spooky-town.domain.user.use-case :refer [->UserUseCaseImpl]]
+   [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
+   [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
    [kit.spooky-town.web.controllers.password :as password]))
 
 (deftest request-password-reset-test
@@ -15,7 +17,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
         test-email "test@example.com"
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"]
 
@@ -95,7 +99,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"]
 
     (testing "비밀번호 초기화 - 성공"

--- a/test/clj/kit/spooky_town/web/controllers/user_test.clj
+++ b/test/clj/kit/spooky_town/web/controllers/user_test.clj
@@ -4,6 +4,8 @@
             [kit.spooky-town.domain.user.test.repository :as user-repository-fixture :refer [->TestUserRepository]]
             [kit.spooky-town.domain.user.test.password-gateway :as password-gateway-fixture :refer [->TestPasswordGateway]]
             [kit.spooky-town.domain.user.test.token-gateway :as token-gateway-fixture :refer [->TestTokenGateway]]
+            [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
+            [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
             [kit.spooky-town.domain.event.test.subscriber :refer [->TestEventSubscriber]] 
             [kit.spooky-town.domain.user.use-case :refer [->UserUseCaseImpl]]
             
@@ -15,10 +17,12 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid test-uuid
-                  :email "test@example.com"}]
+                   :email "test@example.com"}]
 
     (testing "유효한 비밀번호로 회원 탈퇴"
       (with-redefs [password-gateway-fixture/verify-password (fn [_ _ _] true)
@@ -70,7 +74,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
         admin-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         user-uuid #uuid "660e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid admin-uuid
@@ -149,7 +155,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)]
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
 
     (testing "유효한 정보로 회원 등록"
       (with-redefs [user-repository-fixture/find-by-email (fn [_ _] nil)
@@ -202,7 +210,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)]
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
 
     (testing "유효한 인증 정보로 로그인"
       (with-redefs [user-repository-fixture/find-by-email
@@ -265,7 +275,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid test-uuid
                   :email "test@example.com"
@@ -339,7 +351,9 @@
         token-gateway (->TestTokenGateway)
         user-repository (->TestUserRepository)
         event-subscriber (->TestEventSubscriber)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
         admin-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         user-uuid #uuid "660e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid admin-uuid

--- a/test/clj/kit/spooky_town/web/controllers/user_test.clj
+++ b/test/clj/kit/spooky_town/web/controllers/user_test.clj
@@ -6,6 +6,7 @@
             [kit.spooky-town.domain.user.test.token-gateway :as token-gateway-fixture :refer [->TestTokenGateway]]
             [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
             [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
+            [kit.spooky-town.domain.user.test.email-verification-gateway-fixture :as email-verification-gateway-fixture :refer [->TestEmailVerificationGateway]]
             [kit.spooky-town.domain.event.test.subscriber :refer [->TestEventSubscriber]] 
             [kit.spooky-town.domain.user.use-case :refer [->UserUseCaseImpl]]
             
@@ -19,7 +20,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid test-uuid
                    :email "test@example.com"}]
@@ -76,7 +78,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         admin-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         user-uuid #uuid "660e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid admin-uuid
@@ -157,7 +160,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)]
 
     (testing "유효한 정보로 회원 등록"
       (with-redefs [user-repository-fixture/find-by-email (fn [_ _] nil)
@@ -212,7 +216,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)]
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)]
 
     (testing "유효한 인증 정보로 로그인"
       (with-redefs [user-repository-fixture/find-by-email
@@ -277,11 +282,12 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         test-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid test-uuid
-                  :email "test@example.com"
-                  :token "valid-token"}]
+                   :email "test@example.com"
+                   :token "valid-token"}]
 
     (testing "유효한 정보로 프로필 업데이트"
       (with-redefs [token-gateway-fixture/verify (fn [_ _] test-uuid)
@@ -353,7 +359,8 @@
         event-subscriber (->TestEventSubscriber)
         email-gateway (->TestEmailGateway)
         email-token-gateway (->TestEmailTokenGateway)
-        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)
         admin-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
         user-uuid #uuid "660e8400-e29b-41d4-a716-446655440000"
         auth-user {:uuid admin-uuid

--- a/test/clj/kit/spooky_town/web/controllers/user_test.clj
+++ b/test/clj/kit/spooky_town/web/controllers/user_test.clj
@@ -1,16 +1,16 @@
 (ns kit.spooky-town.web.controllers.user-test
-  (:require [clojure.test :refer :all]
-            [kit.spooky-town.web.controllers.user :as user]
-            [kit.spooky-town.domain.user.test.repository :as user-repository-fixture :refer [->TestUserRepository]]
-            [kit.spooky-town.domain.user.test.password-gateway :as password-gateway-fixture :refer [->TestPasswordGateway]]
-            [kit.spooky-town.domain.user.test.token-gateway :as token-gateway-fixture :refer [->TestTokenGateway]]
-            [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
-            [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
-            [kit.spooky-town.domain.user.test.email-verification-gateway-fixture :as email-verification-gateway-fixture :refer [->TestEmailVerificationGateway]]
-            [kit.spooky-town.domain.event.test.subscriber :refer [->TestEventSubscriber]] 
-            [kit.spooky-town.domain.user.use-case :refer [->UserUseCaseImpl]]
-            
-            [ring.mock.request :as mock]))
+  (:require
+   [clojure.test :refer :all]
+   [failjure.core :as f]
+   [kit.spooky-town.domain.event.test.subscriber :refer [->TestEventSubscriber]]
+   [kit.spooky-town.domain.user.test.email-gateway-fixture :as email-gateway-fixture :refer [->TestEmailGateway]]
+   [kit.spooky-town.domain.user.test.email-token-gateway-fixture :as email-token-gateway-fixture :refer [->TestEmailTokenGateway]]
+   [kit.spooky-town.domain.user.test.email-verification-gateway-fixture :as email-verification-gateway-fixture :refer [->TestEmailVerificationGateway]]
+   [kit.spooky-town.domain.user.test.password-gateway :as password-gateway-fixture :refer [->TestPasswordGateway]]
+   [kit.spooky-town.domain.user.test.repository :as user-repository-fixture :refer [->TestUserRepository]]
+   [kit.spooky-town.domain.user.test.token-gateway :as token-gateway-fixture :refer [->TestTokenGateway]]
+   [kit.spooky-town.domain.user.use-case :refer [->UserUseCaseImpl]]
+   [kit.spooky-town.web.controllers.user :as user]))
 
 (deftest withdraw-test
   (let [with-tx (fn [repo f] (f repo))
@@ -440,3 +440,81 @@
               response (user/update-user-role request)]
           (is (= 400 (:status response)))
           (is (= "탈퇴한 사용자입니다" (get-in response [:body :error]))))))))
+
+(deftest request-email-verification-test
+  (let [with-tx (fn [repo f] (f repo))
+        password-gateway (->TestPasswordGateway)
+        token-gateway (->TestTokenGateway)
+        user-repository (->TestUserRepository)
+        event-subscriber (->TestEventSubscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)]
+
+    (testing "유효한 이메일로 인증 요청"
+      (with-redefs [user-repository-fixture/find-by-email
+                    (fn [_ _] 
+                      {:email "test@example.com"
+                       :name "Test User"})
+                    email-token-gateway-fixture/generate-token
+                    (fn [_ _ _] "test-token")
+                    email-gateway-fixture/send-verification-email
+                    (fn [_ _ _] nil)
+                    email-verification-gateway-fixture/save-verification-status!
+                    (fn [_ _ _ _] nil)]
+        (let [request {:body-params {:email "test@example.com"}
+                      :user-use-case user-use-case}
+              response (user/request-email-verification request)]
+          (is (= 200 (:status response)))
+          (is (= "이메일 인증 링크가 발송되었습니다" (get-in response [:body :message]))))))
+
+    (testing "존재하지 않는 이메일로 인증 요청"
+      (with-redefs [user-repository-fixture/find-by-email (fn [_ _] nil)
+                    email-token-gateway-fixture/generate-token
+                    (fn [_ _ _] "test-token")
+                    email-gateway-fixture/send-verification-email
+                    (fn [_ _ _] nil)
+                    email-verification-gateway-fixture/save-verification-status!
+                    (fn [_ _ _ _] nil)]
+        (let [request {:body-params {:email "nonexistent@example.com"}
+                      :user-use-case user-use-case}
+              response (user/request-email-verification request)]
+          (is (= 404 (:status response)))
+          (is (= "사용자를 찾을 수 없습니다" (get-in response [:body :error]))))))))
+
+(deftest verify-email-test
+  (let [with-tx (fn [repo f] (f repo))
+        password-gateway (->TestPasswordGateway)
+        token-gateway (->TestTokenGateway)
+        user-repository (->TestUserRepository)
+        event-subscriber (->TestEventSubscriber)
+        email-gateway (->TestEmailGateway)
+        email-token-gateway (->TestEmailTokenGateway)
+        email-verification-gateway (->TestEmailVerificationGateway)
+        user-use-case (->UserUseCaseImpl with-tx password-gateway token-gateway user-repository event-subscriber email-gateway email-token-gateway email-verification-gateway)]
+
+    (testing "유효한 토큰으로 이메일 인증"
+      (with-redefs [email-token-gateway-fixture/verify-token
+                    (fn [_ _] {:email "test@example.com"})
+                    user-repository-fixture/find-by-email
+                    (fn [_ _] 
+                      {:email "test@example.com"
+                       :name "Test User"})
+                    email-verification-gateway-fixture/save-verification-status!
+                    (fn [_ _ _ _] nil)]
+        (let [request {:body-params {:token "valid-token"}
+                      :user-use-case user-use-case}
+              response (user/verify-email request)]
+          (is (= 200 (:status response)))
+          (is (= "이메일 인증이 완료되었습니다" (get-in response [:body :message]))))))
+
+    (testing "유효하지 않은 토큰으로 인증 시도"
+      (with-redefs [email-token-gateway-fixture/verify-token
+                    (fn [_ _] (f/fail :verification-error/invalid-token))]
+        (let [request {:body-params {:token "invalid-token"}
+                      :user-use-case user-use-case}
+              response (user/verify-email request)]
+          (is (= 400 (:status response)))
+          (is (= "유효하지 않은 토큰입니다" (get-in response [:body :error]))))))))
+


### PR DESCRIPTION

# 주요 변경사항
- 이메일 인증 관련 도메인 로직 추가
  - EmailGateway: 이메일 발송 인터페이스
  - EmailTokenGateway: 이메일 인증 토큰 관리
  - EmailVerificationGateway: 이메일 인증 상태 관리

- 인프라스트럭처 구현
  - SMTPEmailGateway: SMTP를 통한 이메일 발송
  - JWTEmailTokenGateway: JWT 기반 이메일 인증 토큰

- 라우터 구조 개선
  - 도메인별 라우터 분리 (auth, user, role-request, admin)
  - 인증 미들웨어 설정 분리 (common.clj)
  - 인증이 필요한 엔드포인트 명확화

- 테스트 코드 추가
  - 이메일 인증 관련 테스트 케이스
  - Gateway 구현체 테스트

# 기술적 결정사항
1. JWT 사용: 이메일 인증 토큰에 JWT 사용 (buddy-sign 라이브러리)
2. SMTP: 이메일 발송에 postal 라이브러리 사용
3. 토큰 만료 시간
   - 회원가입: 24시간
   - 비밀번호 초기화: 1시간
   - 이메일 변경: 1시간

# 테스트
- [x] 단위 테스트 추가
- [x] 통합 테스트 추가
- [x] 수동 테스트 완료

# 설정 필요사항
환경 변수 추가 필요:
- SMTP_HOST
- SMTP_PORT
- SMTP_USER
- SMTP_PASS
- SMTP_FROM
- BASE_URL
- EMAIL_TOKEN_SECRET