### PR TITLE
영화 도메인 모델 구현

### DIFF
--- a/src/clj/kit/spooky_town/domain/common/image.clj
+++ b/src/clj/kit/spooky_town/domain/common/image.clj
@@ -1,0 +1,24 @@
+(ns kit.spooky-town.domain.common.image
+  (:require [clojure.spec.alpha :as s]))
+
+;; 이미지 제약조건
+(def max-dimension 12000)           ;; 최대 12000px
+(def max-area (* 100 1000 1000))   ;; 최대 100 메가픽셀
+(def max-size (* 10 1024 1024))    ;; 최대 10MB
+(def allowed-types #{"jpeg" "png" "jpg"})
+
+;; 이미지 스펙
+(s/def ::file-name string?)
+(s/def ::file-type allowed-types)
+(s/def ::width (s/and pos-int? #(<= % max-dimension)))
+(s/def ::height (s/and pos-int? #(<= % max-dimension)))
+(s/def ::size (s/and pos-int? #(<= % max-size)))
+(s/def ::area #(<= (* (:width %) (:height %)) max-area))
+
+(s/def ::image
+  (s/and (s/keys :req-un [::file-name ::file-type ::width ::height ::size])
+         ::area))
+
+(defn create-image [{:keys [file-name file-type width height size] :as image}]
+  (when (s/valid? ::image image)
+    image)) 

--- a/src/clj/kit/spooky_town/domain/common/image.clj
+++ b/src/clj/kit/spooky_town/domain/common/image.clj
@@ -1,24 +1,41 @@
 (ns kit.spooky-town.domain.common.image
   (:require [clojure.spec.alpha :as s]))
 
-;; 이미지 제약조건
-(def max-dimension 12000)           ;; 최대 12000px
-(def max-area (* 100 1000 1000))   ;; 최대 100 메가픽셀
-(def max-size (* 10 1024 1024))    ;; 최대 10MB
+;; 파일 제약조건
+(def max-file-size (* 10 1024 1024))    ;; 최대 10MB
 (def allowed-types #{"jpeg" "png" "jpg"})
 
-;; 이미지 스펙
+;; 이미지 차원 제약조건
+(def max-dimension 12000)           ;; 최대 12000px
+(def max-area (* 100 1000 1000))   ;; 최대 100 메가픽셀
+
+;; 업로드할 파일 스펙
 (s/def ::file-name string?)
 (s/def ::file-type allowed-types)
-(s/def ::width (s/and pos-int? #(<= % max-dimension)))
-(s/def ::height (s/and pos-int? #(<= % max-dimension)))
-(s/def ::size (s/and pos-int? #(<= % max-size)))
-(s/def ::area #(<= (* (:width %) (:height %)) max-area))
+(s/def ::file-size (s/and pos-int? #(<= % max-file-size)))
+(s/def ::width (s/nilable (s/and pos-int? #(<= % max-dimension))))
+(s/def ::height (s/nilable (s/and pos-int? #(<= % max-dimension))))
+(s/def ::area #(if (and (:width %) (:height %))
+                 (<= (* (:width %) (:height %)) max-area)
+                 true))
 
-(s/def ::image
-  (s/and (s/keys :req-un [::file-name ::file-type ::width ::height ::size])
+(s/def ::upload-file
+  (s/and (s/keys :req-un [::file-name ::file-type ::file-size]
+                 :opt-un [::width ::height])
          ::area))
 
-(defn create-image [{:keys [file-name file-type width height size] :as image}]
+;; 업로드된 이미지 스펙
+(s/def ::url string?)
+
+(s/def ::image
+  (s/and (s/keys :req-un [::url]
+                 :opt-un [::width ::height])
+         ::area))
+
+(defn create-upload-file [{:keys [file-name file-type file-size] :as file}]
+  (when (s/valid? ::upload-file file)
+    file))
+
+(defn create-image [{:keys [url width height] :as image}]
   (when (s/valid? ::image image)
     image)) 

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -26,17 +26,24 @@
           :opt-un [::movie-actors ::runtime ::poster]))
 
 ;; 생성 함수
-(defn create-movie [{:keys [uuid title director-ids release-info genres] :as movie}]
+(defn create-movie [{:keys [uuid title director-ids release-info genres
+                           movie-actors runtime poster] :as movie}]
   (let [created-title (value/create-title title)
         created-director-ids (value/create-director-ids director-ids)
         created-release-info (value/create-release-info release-info)
-        created-genres (value/create-genres genres)]
+        created-genres (value/create-genres genres)
+        created-movie-actors (when movie-actors (value/create-movie-actors movie-actors))
+        created-runtime (when runtime (value/create-runtime runtime))
+        created-poster (when poster (image/create-image poster))]
     (when (and uuid created-title created-director-ids created-release-info created-genres)
       (let [now (java.util.Date.)]
-        {:uuid uuid
-         :created-at now
-         :updated-at now
-         :title title
-         :director-ids director-ids
-         :release-info release-info
-         :genres genres})))) 
+        (cond-> {:uuid uuid
+                 :created-at now
+                 :updated-at now
+                 :title title
+                 :director-ids director-ids
+                 :release-info release-info
+                 :genres genres}
+          movie-actors (assoc :movie-actors movie-actors)
+          runtime (assoc :runtime runtime)
+          poster (assoc :poster poster)))))) 

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -1,0 +1,42 @@
+(ns kit.spooky-town.domain.movie.entity
+  (:require [clojure.spec.alpha :as s]
+            [kit.spooky-town.domain.movie.value :as value]
+            [kit.spooky-town.domain.common.image :as image]))
+
+;; 식별성 관련 스펙
+(s/def ::uuid uuid?)
+(s/def ::created-at inst?)
+(s/def ::updated-at inst?)
+
+;; 필수 속성 스펙 (값 객체 활용)
+(s/def ::title ::value/title)
+(s/def ::director-ids ::value/director-ids)
+(s/def ::release-info ::value/release-info)
+(s/def ::genres ::value/genres)
+
+;; 선택 속성 스펙 (값 객체 활용)
+(s/def ::movie-actors ::value/movie-actors)
+(s/def ::runtime ::value/runtime)
+(s/def ::poster ::image/image)
+
+;; 영화 엔티티 스펙
+(s/def ::movie
+  (s/keys :req-un [::uuid ::created-at ::updated-at
+                   ::title ::director-ids ::release-info ::genres]
+          :opt-un [::movie-actors ::runtime ::poster]))
+
+;; 생성 함수
+(defn create-movie [{:keys [uuid title director-ids release-info genres] :as movie}]
+  (let [created-title (value/create-title title)
+        created-director-ids (value/create-director-ids director-ids)
+        created-release-info (value/create-release-info release-info)
+        created-genres (value/create-genres genres)]
+    (when (and uuid created-title created-director-ids created-release-info created-genres)
+      (let [now (java.util.Date.)]
+        {:uuid uuid
+         :created-at now
+         :updated-at now
+         :title title
+         :director-ids director-ids
+         :release-info release-info
+         :genres genres})))) 

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -1,0 +1,26 @@
+(ns kit.spooky-town.domain.movie.value
+  (:require [clojure.spec.alpha :as s]))
+
+;; 제목 (필수)
+(def max-title-length 200)
+(s/def ::title (s/and string? 
+                      #(pos? (count %))
+                      #(<= (count %) max-title-length)))
+
+;; 감독 (필수)
+(def max-director-name-length 20)
+(s/def ::director-name (s/and string? 
+                             #(pos? (count %))
+                             #(<= (count %) max-director-name-length)))
+(s/def ::director (s/keys :req-un [::director-name]))
+(s/def ::directors (s/and (s/coll-of ::director :kind vector?)
+                         #(pos? (count %))))  ;; 최소 1명 이상
+
+;; 기본 생성 함수들
+(defn create-title [title]
+  (when (s/valid? ::title title)
+    title))
+
+(defn create-directors [directors]
+  (when (s/valid? ::directors directors)
+    directors)) 

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -63,4 +63,11 @@
 
 (defn create-genres [genres]
   (when (s/valid? ::genres genres)
-    genres)) 
+    genres))
+
+;; 상영시간 (분 단위, 양수)
+(s/def ::runtime (s/and pos-int? #(pos? %)))
+
+(defn create-runtime [runtime]
+  (when (s/valid? ::runtime runtime)
+    runtime)) 

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -9,13 +9,31 @@
                       #(<= (count %) max-title-length)))
 
 ;; 감독 (필수)
+;; 입력용 값 객체
 (def max-director-name-length 20)
 (s/def ::director-name (s/and string? 
                              #(pos? (count %))
                              #(<= (count %) max-director-name-length)))
-(s/def ::director (s/keys :req-un [::director-name]))
-(s/def ::directors (s/and (s/coll-of ::director :kind vector?)
-                         #(pos? (count %))))  ;; 최소 1명 이상
+(s/def ::director-input (s/keys :req-un [::director-name]))
+(s/def ::director-inputs (s/and (s/coll-of ::director-input :kind vector?)
+                               #(pos? (count %))))
+
+;; 저장용 값 객체
+(s/def ::director-id pos-int?)
+(s/def ::director-ids (s/and (s/coll-of ::director-id :kind vector?)
+                            #(pos? (count %))))
+
+(defn create-director-input [director]
+  (when (s/valid? ::director-input director)
+    director))
+
+(defn create-director-inputs [directors]
+  (when (s/valid? ::director-inputs directors)
+    directors))
+
+(defn create-director-ids [ids]
+  (when (s/valid? ::director-ids ids)
+    ids))
 
 ;; 장르 (필수로 호러나 스릴러를 포함해야 함)
 (s/def ::primary-genre #{:horror :thriller})
@@ -74,21 +92,36 @@
     runtime))
 
 ;; 배우 정보
+;; 입력용 값 객체
 (def max-actor-name-length 50)
 (s/def ::actor-name (s/and string? 
                           #(pos? (count %))
                           #(<= (count %) max-actor-name-length)))
-(s/def ::role string?)  ;; 배역 이름
-(s/def ::actor (s/keys :req-un [::actor-name]
-                       :opt-un [::role]))
-(s/def ::actors (s/coll-of ::actor :kind vector?))
+(s/def ::role string?)
+(s/def ::actor-input (s/keys :req-un [::actor-name]
+                            :opt-un [::role]))
+(s/def ::actor-inputs (s/coll-of ::actor-input :kind vector?))
 
-(defn create-actor [{:keys [actor-name role] :as actor}]
-  (when (s/valid? ::actor actor)
+;; 저장용 값 객체
+(s/def ::actor-id pos-int?)
+(s/def ::movie-actor {:actor-id ::actor-id
+                      :role (s/nilable ::role)})
+(s/def ::movie-actors (s/coll-of ::movie-actor :kind vector?))
+
+(defn create-actor-input [actor]
+  (when (s/valid? ::actor-input actor)
     actor))
 
-(defn create-actors [actors]
-  (when (s/valid? ::actors actors)
+(defn create-actor-inputs [actors]
+  (when (s/valid? ::actor-inputs actors)
+    actors))
+
+(defn create-movie-actor [{:keys [actor-id role] :as actor}]
+  (when (s/valid? ::movie-actor actor)
+    actor))
+
+(defn create-movie-actors [actors]
+  (when (s/valid? ::movie-actors actors)
     actors))
 
 ;; 포스터 (이미지 값 객체 사용)

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -45,10 +45,12 @@
                           :gore           ;; 고어
                           :mystery})      ;; 미스터리
 
-(s/def ::genres (s/and (s/coll-of (s/or :primary ::primary-genre
-                                        :secondary ::secondary-genre)
-                                  :kind set?)
-                       #(some ::primary-genre %)))  ;; horror나 thriller 중 하나는 반드시 포함
+(s/def ::genres (s/and (s/coll-of keyword? :kind set?)
+                       #(or (contains? % :horror)
+                           (contains? % :thriller))
+                       #(every? (fn [genre] (or (contains? #{:horror :thriller} genre)
+                                              (contains? #{:psychological :supernatural :slasher 
+                                                         :zombie :monster :gore :mystery} genre))) %)))
 
 ;; 개봉 상태와 날짜
 (s/def ::release-status #{:released        ;; 개봉됨
@@ -61,15 +63,9 @@
   (s/keys :req-un [::release-status]
           :opt-un [::release-date]))
 
-(defn create-release-info
-  ([status]
-   (when (s/valid? ::release-status status)
-     {:release-status status}))
-  ([status date]
-   (when (and (s/valid? ::release-status status)
-              (s/valid? ::release-date date))
-     {:release-status status
-      :release-date date})))
+(defn create-release-info [{:keys [release-status release-date] :as release-info}]
+  (when (s/valid? ::release-info release-info)
+    release-info))
 
 ;; 기본 생성 함수들
 (defn create-title [title]

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -1,5 +1,6 @@
 (ns kit.spooky-town.domain.movie.value
-  (:require [clojure.spec.alpha :as s]))
+  (:require [clojure.spec.alpha :as s]
+            [kit.spooky-town.domain.common.image :as image]))
 
 ;; 제목 (필수)
 (def max-title-length 200)
@@ -88,4 +89,10 @@
 
 (defn create-actors [actors]
   (when (s/valid? ::actors actors)
-    actors)) 
+    actors))
+
+;; 포스터 (이미지 값 객체 사용)
+(s/def ::poster ::image/image)
+
+(defn create-poster [poster]
+  (image/create-image poster)) 

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -70,4 +70,22 @@
 
 (defn create-runtime [runtime]
   (when (s/valid? ::runtime runtime)
-    runtime)) 
+    runtime))
+
+;; 배우 정보
+(def max-actor-name-length 50)
+(s/def ::actor-name (s/and string? 
+                          #(pos? (count %))
+                          #(<= (count %) max-actor-name-length)))
+(s/def ::role string?)  ;; 배역 이름
+(s/def ::actor (s/keys :req-un [::actor-name]
+                       :opt-un [::role]))
+(s/def ::actors (s/coll-of ::actor :kind vector?))
+
+(defn create-actor [{:keys [actor-name role] :as actor}]
+  (when (s/valid? ::actor actor)
+    actor))
+
+(defn create-actors [actors]
+  (when (s/valid? ::actors actors)
+    actors)) 

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -31,6 +31,26 @@
                                   :kind set?)
                        #(some ::primary-genre %)))  ;; horror나 thriller 중 하나는 반드시 포함
 
+;; 개봉 상태와 날짜
+(s/def ::release-status #{:released        ;; 개봉됨
+                         :upcoming         ;; 개봉 예정
+                         :unknown})        ;; 미정
+
+(s/def ::release-date inst?)              ;; 실제 개봉일 또는 개봉 예정일
+(s/def ::release-info 
+  (s/keys :req-un [::release-status]
+          :opt-un [::release-date]))
+
+(defn create-release-info
+  ([status]
+   (when (s/valid? ::release-status status)
+     {:release-status status}))
+  ([status date]
+   (when (and (s/valid? ::release-status status)
+              (s/valid? ::release-date date))
+     {:release-status status
+      :release-date date})))
+
 ;; 기본 생성 함수들
 (defn create-title [title]
   (when (s/valid? ::title title)

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -36,7 +36,8 @@
                          :upcoming         ;; 개봉 예정
                          :unknown})        ;; 미정
 
-(s/def ::release-date inst?)              ;; 실제 개봉일 또는 개봉 예정일
+(def date-regex #"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$")
+(s/def ::release-date (s/and string? #(re-matches date-regex %)))
 (s/def ::release-info 
   (s/keys :req-un [::release-status]
           :opt-un [::release-date]))

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -16,6 +16,21 @@
 (s/def ::directors (s/and (s/coll-of ::director :kind vector?)
                          #(pos? (count %))))  ;; 최소 1명 이상
 
+;; 장르 (필수로 호러나 스릴러를 포함해야 함)
+(s/def ::primary-genre #{:horror :thriller})
+(s/def ::secondary-genre #{:psychological   ;; 심리
+                          :supernatural    ;; 초자연
+                          :slasher        ;; 슬래셔
+                          :zombie         ;; 좀비
+                          :monster        ;; 몬스터
+                          :gore           ;; 고어
+                          :mystery})      ;; 미스터리
+
+(s/def ::genres (s/and (s/coll-of (s/or :primary ::primary-genre
+                                        :secondary ::secondary-genre)
+                                  :kind set?)
+                       #(some ::primary-genre %)))  ;; horror나 thriller 중 하나는 반드시 포함
+
 ;; 기본 생성 함수들
 (defn create-title [title]
   (when (s/valid? ::title title)
@@ -23,4 +38,8 @@
 
 (defn create-directors [directors]
   (when (s/valid? ::directors directors)
-    directors)) 
+    directors))
+
+(defn create-genres [genres]
+  (when (s/valid? ::genres genres)
+    genres)) 

--- a/test/clj/kit/spooky_town/domain/movie/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/entity_test.clj
@@ -10,6 +10,15 @@
                  :release-date "2024-12-25"}
    :genres #{:horror :psychological}})
 
+(def valid-movie-with-optional
+  (assoc valid-movie-data
+         :movie-actors [{:actor-id 1 :role "주연"}
+                       {:actor-id 2 :role "조연"}]
+         :runtime 120
+         :poster {:url "http://example.com/poster.jpg"
+                 :width 600
+                 :height 800}))
+
 (deftest create-movie-test
   (testing "필수 속성으로 영화 생성"
     (let [movie (entity/create-movie valid-movie-data)]
@@ -26,6 +35,16 @@
         (is (inst? (:updated-at movie)))
         (is (= (:created-at movie) (:updated-at movie))))))
 
+  (testing "선택 속성을 포함한 영화 생성"
+    (let [movie (entity/create-movie valid-movie-with-optional)]
+      (testing "선택 속성 검증"
+        (is (= (:movie-actors movie) 
+               (:movie-actors valid-movie-with-optional)))
+        (is (= (:runtime movie) 
+               (:runtime valid-movie-with-optional)))
+        (is (= (:poster movie) 
+               (:poster valid-movie-with-optional))))))
+
   (testing "영화 생성 실패 케이스"
     (testing "UUID 없는 경우"
       (is (nil? (entity/create-movie (dissoc valid-movie-data :uuid)))))
@@ -41,4 +60,5 @@
     
     (testing "장르에 horror/thriller 둘 다 없는 경우"
       (is (nil? (entity/create-movie 
-                 (assoc valid-movie-data :genres #{:psychological :zombie}))))))) 
+                 (assoc valid-movie-data :genres #{:psychological :zombie})))))))
+

--- a/test/clj/kit/spooky_town/domain/movie/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/entity_test.clj
@@ -1,0 +1,44 @@
+(ns kit.spooky-town.domain.movie.entity-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.movie.entity :as entity]))
+
+(def valid-movie-data
+  {:uuid #uuid "00000000-0000-0000-0000-000000000000"
+   :title "스푸키 타운의 비밀"
+   :director-ids [1 2]
+   :release-info {:release-status :upcoming
+                 :release-date "2024-12-25"}
+   :genres #{:horror :psychological}})
+
+(deftest create-movie-test
+  (testing "필수 속성으로 영화 생성"
+    (let [movie (entity/create-movie valid-movie-data)]
+      (testing "기본 속성 검증"
+        (is (some? movie))
+        (is (= (:uuid movie) (:uuid valid-movie-data)))
+        (is (= (:title movie) "스푸키 타운의 비밀"))
+        (is (= (:director-ids movie) [1 2]))
+        (is (= (get-in movie [:release-info :release-status]) :upcoming))
+        (is (contains? (:genres movie) :horror)))
+
+      (testing "생성/수정 시간 자동 설정"
+        (is (inst? (:created-at movie)))
+        (is (inst? (:updated-at movie)))
+        (is (= (:created-at movie) (:updated-at movie))))))
+
+  (testing "영화 생성 실패 케이스"
+    (testing "UUID 없는 경우"
+      (is (nil? (entity/create-movie (dissoc valid-movie-data :uuid)))))
+
+    (testing "제목 없는 경우"
+      (is (nil? (entity/create-movie (dissoc valid-movie-data :title)))))
+    
+    (testing "감독 ID 없는 경우"
+      (is (nil? (entity/create-movie (dissoc valid-movie-data :director-ids)))))
+    
+    (testing "감독 ID가 빈 배열인 경우"
+      (is (nil? (entity/create-movie (assoc valid-movie-data :director-ids [])))))
+    
+    (testing "장르에 horror/thriller 둘 다 없는 경우"
+      (is (nil? (entity/create-movie 
+                 (assoc valid-movie-data :genres #{:psychological :zombie}))))))) 


### PR DESCRIPTION
# 주요 변경사항

## 도메인 모델
- 영화 엔티티 (Movie Entity)
  - 필수 속성: UUID, 제목, 감독 ID, 개봉 정보, 장르
  - 선택 속성: 배우, 상영 시간, 포스터
- 값 객체 (Value Objects)
  - 제목, 감독, 배우, 장르, 개봉 정보 등
  - 각 값 객체별 유효성 검증 규칙 정의

## 공통 컴포넌트
- 이미지 값 객체 추가
  - 파일 크기, 타입, 차원 제약 조건
  - 업로드/저장 형식 구분

## 테스트
- 엔티티 생성 테스트
  - 필수 속성만으로 생성
  - 선택 속성 포함 생성
  - 유효성 검증 실패 케이스

# 기술적 결정사항
1. 감독/배우의 다대다 관계
   - 입력: 이름 기반 (director-input/actor-input)
   - 저장: ID 기반 (director-ids/movie-actors)

2. 장르 제약
   - horror/thriller 중 하나는 필수
   - 추가 장르는 선택적 지정 가능

3. 이미지 처리
   - 파일 크기 제한: 10MB
   - 허용 포맷: jpeg, png, jpg
   - 최대 차원: 12000px
   - 최대 면적: 100 메가픽셀

# 테스트 결과
- 모든 테스트 케이스 통과

#관련 이슈
closes #17 
