### PR TITLE
 영화 정보 업데이트 기능 추가

### DIFF
--- a/src/clj/kit/spooky_town/core.clj
+++ b/src/clj/kit/spooky_town/core.clj
@@ -14,6 +14,7 @@
    ;; Routes
    [kit.spooky-town.web.routes.api]
    [kit.spooky-town.web.middleware.auth]
+   [kit.spooky-town.web.middleware.multipart]
 
    ;; Infrastructure
    [kit.spooky-town.infrastructure.email.smtp-gateway]

--- a/src/clj/kit/spooky_town/domain/common/image.clj
+++ b/src/clj/kit/spooky_town/domain/common/image.clj
@@ -24,9 +24,13 @@
                  :opt-un [::width ::height])
          ::area))
 
-;; 업로드된 이미지 스펙
-(s/def ::url string?)
+;; 이미지 URL 제약조건
+(def url-pattern #"^https?://.*")
+(s/def ::url (s/and string? 
+                    not-empty 
+                    #(re-matches url-pattern %)))
 
+;; 업로드된 이미지 스펙
 (s/def ::image
   (s/and (s/keys :req-un [::url]
                  :opt-un [::width ::height])
@@ -37,5 +41,6 @@
     file))
 
 (defn create-image [{:keys [url width height] :as image}]
-  (when (s/valid? ::image image)
+  (when (and (s/valid? ::image image)
+             (re-matches url-pattern url))
     image)) 

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -72,6 +72,13 @@
                :updated-at (java.util.Date.))
         (create-movie))))
 
+(defn update-genres [movie new-genres]
+  (when-let [validated-genres (value/create-genres new-genres)]
+    (-> movie
+        (assoc :genres validated-genres
+               :updated-at (java.util.Date.))
+        (create-movie))))
+
 (defn update-release-info [movie new-release-info]
   (when-let [validated-release-info (value/create-release-info new-release-info)]
     (-> movie

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -71,3 +71,10 @@
         (assoc :runtime validated-runtime
                :updated-at (java.util.Date.))
         (create-movie))))
+
+(defn update-genres [movie new-genres]
+  (when-let [validated-genres (value/create-genres new-genres)]
+    (-> movie
+        (assoc :genres validated-genres
+               :updated-at (java.util.Date.))
+        (create-movie))))

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -58,30 +58,28 @@
                       (mapv :name (:directors movie)))
      :release-status release-status}))
 
-(defn update-title [movie new-title]
+(defn- update-title [movie new-title]
   (when-let [validated-title (value/create-title new-title)]
-    (-> movie
-        (assoc :title validated-title
-               :updated-at (java.util.Date.))
-        (create-movie))))
+    (assoc movie :title validated-title)))
 
-(defn update-runtime [movie new-runtime]
+(defn- update-runtime [movie new-runtime]
   (when-let [validated-runtime (value/create-runtime new-runtime)]
-    (-> movie
-        (assoc :runtime validated-runtime
-               :updated-at (java.util.Date.))
-        (create-movie))))
+    (assoc movie :runtime validated-runtime)))
 
-(defn update-genres [movie new-genres]
+(defn- update-genres [movie new-genres]
   (when-let [validated-genres (value/create-genres new-genres)]
-    (-> movie
-        (assoc :genres validated-genres
-               :updated-at (java.util.Date.))
-        (create-movie))))
+    (assoc movie :genres validated-genres)))
 
-(defn update-release-info [movie new-release-info]
+(defn- update-release-info [movie new-release-info]
   (when-let [validated-release-info (value/create-release-info new-release-info)]
-    (-> movie
-        (assoc :release-info validated-release-info
-               :updated-at (java.util.Date.))
-        (create-movie))))
+    (assoc movie :release-info validated-release-info)))
+
+(defn update-movie [movie {:keys [title runtime genres release-info]}]
+  (when-let [updated (-> movie
+                        (cond-> 
+                          title (update-title title)
+                          runtime (update-runtime runtime)
+                          genres (update-genres genres)
+                          release-info (update-release-info release-info))
+                        (assoc :updated-at (java.util.Date.)))]
+    (create-movie updated)))

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -57,3 +57,10 @@
      :director-names (when (:directors movie)
                       (mapv :name (:directors movie)))
      :release-status release-status}))
+
+(defn update-title [movie new-title]
+  (when-let [validated-title (value/create-title new-title)]
+    (-> movie
+        (assoc :title validated-title
+               :updated-at (java.util.Date.))
+        (create-movie))))

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -72,9 +72,9 @@
                :updated-at (java.util.Date.))
         (create-movie))))
 
-(defn update-genres [movie new-genres]
-  (when-let [validated-genres (value/create-genres new-genres)]
+(defn update-release-info [movie new-release-info]
+  (when-let [validated-release-info (value/create-release-info new-release-info)]
     (-> movie
-        (assoc :genres validated-genres
+        (assoc :release-info validated-release-info
                :updated-at (java.util.Date.))
         (create-movie))))

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -74,12 +74,17 @@
   (when-let [validated-release-info (value/create-release-info new-release-info)]
     (assoc movie :release-info validated-release-info)))
 
-(defn update-movie [movie {:keys [title runtime genres release-info]}]
+(defn- update-poster [movie new-poster]
+  (when-let [validated-poster (value/create-poster new-poster)]
+    (assoc movie :poster validated-poster)))
+
+(defn update-movie [movie {:keys [title runtime genres release-info poster]}]
   (when-let [updated (-> movie
                         (cond-> 
                           title (update-title title)
                           runtime (update-runtime runtime)
                           genres (update-genres genres)
-                          release-info (update-release-info release-info))
+                          release-info (update-release-info release-info)
+                          poster (update-poster poster))
                         (assoc :updated-at (java.util.Date.)))]
     (create-movie updated)))

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -64,3 +64,10 @@
         (assoc :title validated-title
                :updated-at (java.util.Date.))
         (create-movie))))
+
+(defn update-runtime [movie new-runtime]
+  (when-let [validated-runtime (value/create-runtime new-runtime)]
+    (-> movie
+        (assoc :runtime validated-runtime
+               :updated-at (java.util.Date.))
+        (create-movie))))

--- a/src/clj/kit/spooky_town/domain/movie/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/movie/use_case.clj
@@ -100,7 +100,11 @@
           ;; 검증 실패 시
           (f/fail "필수 필드가 유효하지 않습니다.")))))
 
-  (update-movie [_ {:keys [movie-id] :as command}]
+  (update-movie [_ {:keys [movie-id
+                           title
+                           runtime
+                           genres
+                           release-info ] :as command}]
     (with-tx movie-repository
       (fn [repo]
         (if-let [movie (movie-repository/find-by-id repo movie-id)]

--- a/src/clj/kit/spooky_town/domain/movie/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/movie/use_case.clj
@@ -100,16 +100,11 @@
           ;; 검증 실패 시
           (f/fail "필수 필드가 유효하지 않습니다.")))))
 
-  (update-movie [_ {:keys [movie-id title runtime genres release-info] :as command}]
+  (update-movie [_ {:keys [movie-id] :as command}]
     (with-tx movie-repository
       (fn [repo]
         (if-let [movie (movie-repository/find-by-id repo movie-id)]
-          (if-let [updated-movie (-> movie
-                                    (cond-> 
-                                      title (entity/update-title title)
-                                      runtime (entity/update-runtime runtime)
-                                      genres (entity/update-genres genres)
-                                      release-info (entity/update-release-info release-info)))]
+          (if-let [updated-movie (entity/update-movie movie command)]
             (do
               (movie-repository/save! repo updated-movie)
               movie-id)

--- a/src/clj/kit/spooky_town/domain/movie/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie/value.clj
@@ -165,4 +165,10 @@
 
 (s/def ::movie-directors
   (s/coll-of ::movie-director :kind vector?))
+
+(s/def ::poster-file (s/merge ::image/upload-file))
+
+(defn create-poster-file [file]
+  (when (s/valid? ::poster-file file)
+    file))
   

--- a/src/clj/kit/spooky_town/web/controllers/movie.clj
+++ b/src/clj/kit/spooky_town/web/controllers/movie.clj
@@ -24,4 +24,12 @@
   (if-let [movie (movie-query/get-movie-summary movie-query-service path-params)]
     (response/ok movie)
     (response/not-found)))
+
+(defn update-movie [{:keys [path-params multipart-params form-params movie-use-case]}]
+  (let [command (cond-> (merge path-params form-params)
+                 (:poster multipart-params) (assoc :poster-file (:poster multipart-params)))
+        result (movie-use-case/update-movie movie-use-case command)]
+    (if (f/failed? result)
+      (response/bad-request {:error (f/message result)})
+      (response/ok {:movie-id result}))))
  

--- a/src/clj/kit/spooky_town/web/middleware/multipart.clj
+++ b/src/clj/kit/spooky_town/web/middleware/multipart.clj
@@ -1,0 +1,30 @@
+(ns kit.spooky-town.web.middleware.multipart
+  (:require [clojure.java.io :as io])
+  (:import [javax.imageio ImageIO]))
+
+(defn extract-image-dimensions [file]
+  (try
+    (with-open [is (io/input-stream (:tempfile file))]
+      (when-let [image (ImageIO/read is)]
+        {:width (.getWidth image)
+         :height (.getHeight image)}))
+    (catch Exception _
+      nil)))
+
+(defn process-image-file [file]
+  (when file
+    (let [dimensions (extract-image-dimensions file)]
+      (when dimensions
+        (merge dimensions
+               {:file-name (:filename file)
+                :file-type (second (re-find #"image/(.+)" (:content-type file)))
+                :file-size (:size file)
+                :tempfile (:tempfile file)})))))
+
+(defn wrap-multipart-params [handler]
+  (fn [request]
+    (if-let [file (get-in request [:multipart-params :poster])]
+      (if-let [processed-file (process-image-file file)]
+        (handler (assoc-in request [:multipart-params :poster] processed-file))
+        (handler request))
+      (handler request)))) 

--- a/test/clj/kit/spooky_town/domain/movie/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/entity_test.clj
@@ -88,3 +88,51 @@
   (testing "유효하지 않은 영화 엔티티 처리"
     (is (nil? (entity/->summary {})))
     (is (nil? (entity/->summary nil)))))
+
+(deftest update-movie-test
+  (testing "영화 제목 업데이트"
+    (let [movie (entity/create-movie valid-movie-data)
+          updated (entity/update-title movie "새로운 제목")]
+      (is (some? updated))
+      (is (= "새로운 제목" (:title updated)))
+      (is (not= (:updated-at movie) (:updated-at updated)))))
+
+  (testing "영화 상영 시간 업데이트"
+    (let [movie (entity/create-movie valid-movie-with-optional)
+          updated (entity/update-runtime movie 150)]
+      (is (some? updated))
+      (is (= 150 (:runtime updated)))
+      (is (not= (:updated-at movie) (:updated-at updated)))))
+
+  (testing "영화 장르 업데이트"
+    (let [movie (entity/create-movie valid-movie-data)
+          new-genres #{:horror :psychological :gore}
+          updated (entity/update-genres movie new-genres)]
+      (is (some? updated))
+      (is (= new-genres (:genres updated)))
+      (is (not= (:updated-at movie) (:updated-at updated)))))
+
+  (testing "영화 개봉 정보 업데이트"
+    (let [movie (entity/create-movie valid-movie-data)
+          new-release-info {:release-status :released
+                           :release-date "2024-01-01"}
+          updated (entity/update-release-info movie new-release-info)]
+      (is (some? updated))
+      (is (= new-release-info (:release-info updated)))
+      (is (not= (:updated-at movie) (:updated-at updated)))))
+
+  (testing "잘못된 입력값으로 업데이트 시도"
+    (let [movie (entity/create-movie valid-movie-data)]
+      (testing "빈 제목으로 업데이트"
+        (is (nil? (entity/update-title movie ""))))
+      
+      (testing "잘못된 상영 시간으로 업데이트"
+        (is (nil? (entity/update-runtime movie -10))))
+      
+      (testing "필수 장르가 없는 장르셋으로 업데이트"
+        (is (nil? (entity/update-genres movie #{:gore :psychological}))))
+      
+      (testing "잘못된 형식의 개봉일로 업데이트"
+        (is (nil? (entity/update-release-info movie 
+                   {:release-status :released
+                    :release-date "2024-13-45"})))))))

--- a/test/clj/kit/spooky_town/domain/movie/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/entity_test.clj
@@ -90,49 +90,75 @@
     (is (nil? (entity/->summary nil)))))
 
 (deftest update-movie-test
-  (testing "영화 제목 업데이트"
-    (let [movie (entity/create-movie valid-movie-data)
-          updated (entity/update-title movie "새로운 제목")]
-      (is (some? updated))
-      (is (= "새로운 제목" (:title updated)))
-      (is (not= (:updated-at movie) (:updated-at updated)))))
+  (let [movie (entity/create-movie valid-movie-data)]
+    
+    (testing "전체 필드 업데이트"
+      (let [updates {:title "새로운 제목"
+                    :runtime 120
+                    :genres #{:horror :gore}
+                    :release-info {:release-status :released
+                                 :release-date "2024-01-01"}}
+            updated (entity/update-movie movie updates)]
+        (is (some? updated))
+        (is (= "새로운 제목" (:title updated)))
+        (is (= 120 (:runtime updated)))
+        (is (= #{:horror :gore} (:genres updated)))
+        (is (= (:release-info updates) (:release-info updated)))
+        (is (not= (:updated-at movie) (:updated-at updated)))))
 
-  (testing "영화 상영 시간 업데이트"
-    (let [movie (entity/create-movie valid-movie-with-optional)
-          updated (entity/update-runtime movie 150)]
-      (is (some? updated))
-      (is (= 150 (:runtime updated)))
-      (is (not= (:updated-at movie) (:updated-at updated)))))
+    (testing "선택적 필드 업데이트"
+      (testing "제목만 업데이트"
+        (let [updates {:title "새로운 제목"}
+              updated (entity/update-movie movie updates)]
+          (is (some? updated))
+          (is (= "새로운 제목" (:title updated)))
+          (is (= (:runtime movie) (:runtime updated)))
+          (is (= (:genres movie) (:genres updated)))
+          (is (= (:release-info movie) (:release-info updated)))
+          (is (not= (:updated-at movie) (:updated-at updated)))))
 
-  (testing "영화 장르 업데이트"
-    (let [movie (entity/create-movie valid-movie-data)
-          new-genres #{:horror :psychological :gore}
-          updated (entity/update-genres movie new-genres)]
-      (is (some? updated))
-      (is (= new-genres (:genres updated)))
-      (is (not= (:updated-at movie) (:updated-at updated)))))
+      (testing "상영시간만 업데이트"
+        (let [updates {:runtime 120}
+              updated (entity/update-movie movie updates)]
+          (is (some? updated))
+          (is (= (:title movie) (:title updated)))
+          (is (= 120 (:runtime updated)))
+          (is (= (:genres movie) (:genres updated)))
+          (is (= (:release-info movie) (:release-info updated)))
+          (is (not= (:updated-at movie) (:updated-at updated)))))
 
-  (testing "영화 개봉 정보 업데이트"
-    (let [movie (entity/create-movie valid-movie-data)
-          new-release-info {:release-status :released
-                           :release-date "2024-01-01"}
-          updated (entity/update-release-info movie new-release-info)]
-      (is (some? updated))
-      (is (= new-release-info (:release-info updated)))
-      (is (not= (:updated-at movie) (:updated-at updated)))))
+      (testing "장르만 업데이트"
+        (let [updates {:genres #{:horror :gore}}
+              updated (entity/update-movie movie updates)]
+          (is (some? updated))
+          (is (= (:title movie) (:title updated)))
+          (is (= (:runtime movie) (:runtime updated)))
+          (is (= #{:horror :gore} (:genres updated)))
+          (is (= (:release-info movie) (:release-info updated)))
+          (is (not= (:updated-at movie) (:updated-at updated)))))
 
-  (testing "잘못된 입력값으로 업데이트 시도"
-    (let [movie (entity/create-movie valid-movie-data)]
-      (testing "빈 제목으로 업데이트"
-        (is (nil? (entity/update-title movie ""))))
+      (testing "개봉정보만 업데이트"
+        (let [updates {:release-info {:release-status :released
+                                    :release-date "2024-01-01"}}
+              updated (entity/update-movie movie updates)]
+          (is (some? updated))
+          (is (= (:title movie) (:title updated)))
+          (is (= (:runtime movie) (:runtime updated)))
+          (is (= (:genres movie) (:genres updated)))
+          (is (= (:release-info updates) (:release-info updated)))
+          (is (not= (:updated-at movie) (:updated-at updated))))))
+
+    (testing "유효하지 않은 업데이트"
+      (testing "빈 제목"
+        (is (nil? (entity/update-movie movie {:title ""}))))
       
-      (testing "잘못된 상영 시간으로 업데이트"
-        (is (nil? (entity/update-runtime movie -10))))
+      (testing "잘못된 상영시간"
+        (is (nil? (entity/update-movie movie {:runtime -10}))))
       
-      (testing "필수 장르가 없는 장르셋으로 업데이트"
-        (is (nil? (entity/update-genres movie #{:gore :psychological}))))
+      (testing "필수 장르 누락"
+        (is (nil? (entity/update-movie movie {:genres #{:gore :psychological}}))))
       
-      (testing "잘못된 형식의 개봉일로 업데이트"
-        (is (nil? (entity/update-release-info movie 
-                   {:release-status :released
-                    :release-date "2024-13-45"})))))))
+      (testing "잘못된 개봉일"
+        (is (nil? (entity/update-movie movie 
+                   {:release-info {:release-status :released
+                                 :release-date "2024-13-45"}})))))))

--- a/test/clj/kit/spooky_town/domain/movie/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/entity_test.clj
@@ -161,4 +161,30 @@
       (testing "잘못된 개봉일"
         (is (nil? (entity/update-movie movie 
                    {:release-info {:release-status :released
-                                 :release-date "2024-13-45"}})))))))
+                                 :release-date "2024-13-45"}}))))) 
+    
+    (testing "포스터 업데이트"
+      (let [new-poster {:url "http://example.com/new-poster.jpg"
+                       :width 800
+                       :height 1200}
+            updates {:poster new-poster}
+            updated (entity/update-movie movie updates)]
+        (is (some? updated))
+        (is (= new-poster (:poster updated)))
+        (is (not= (:updated-at movie) (:updated-at updated)))))
+
+    (testing "포스터를 포함한 복합 업데이트"
+      (let [updates {:title "새로운 제목"
+                    :poster {:url "http://example.com/new-poster.jpg"
+                            :width 800
+                            :height 1200}}
+            updated (entity/update-movie movie updates)]
+        (is (some? updated))
+        (is (= "새로운 제목" (:title updated)))
+        (is (= (:url (:poster updates)) (:url (:poster updated))))
+        (is (not= (:updated-at movie) (:updated-at updated)))))
+
+    (testing "유효하지 않은 포스터 업데이트"
+      (testing "잘못된 포스터 데이터"
+        (is (nil? (entity/update-movie movie 
+                   {:poster {:url ""}})))))))


### PR DESCRIPTION
# 영화 정보 업데이트 기능 추가

영화의 기본 정보와 포스터 이미지를 업데이트할 수 있는 기능을 추가합니다.

## 주요 변경사항

### 도메인 레이어
- 영화 엔티티 업데이트 기능 추가
  - 제목, 상영시간, 장르, 개봉정보 부분 업데이트 지원
  - 포스터 이미지 업데이트 지원
  - 업데이트 시간 자동 갱신
- 이미지 URL 유효성 검증 강화
  - URL 패턴 검증 (http/https)
  - 빈 문자열 검증
- 포스터 파일 유효성 검증 추가

### 웹 레이어
- PUT /movies/:movie-id 엔드포인트 추가
  - multipart/form-data 지원
  - 선택적 필드 업데이트
  - Swagger 문서화
- 멀티파트 파일 처리 미들웨어 구현
  - 이미지 메타데이터 추출 (크기, 타입)
  - 파일 유효성 검증

### 테스트
- 엔티티 업데이트 테스트
  - 전체/부분 업데이트 케이스
  - 유효하지 않은 데이터 처리
- 유스케이스 테스트
  - 업데이트 성공/실패 케이스
  - 포스터 파일 처리
- 이미지 파일 검증 테스트