### PR TITLE
극장 관계 추가 및 영화 엔티티 업데이트

### DIFF
--- a/resources/migrations/[timestamp]_add_theaters.down.sql
+++ b/resources/migrations/[timestamp]_add_theaters.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE movie_theaters;
+DROP TABLE theaters; 

--- a/resources/migrations/[timestamp]_add_theaters.up.sql
+++ b/resources/migrations/[timestamp]_add_theaters.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE theaters (
+  theater_id VARCHAR(26) PRIMARY KEY,  -- ULID
+  uuid UUID NOT NULL UNIQUE,
+  chain_type VARCHAR(20) NOT NULL,     -- 'cgv', 'megabox', 'lotte'
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_theaters_uuid ON theaters(uuid);
+CREATE INDEX idx_theaters_chain_type ON theaters(chain_type);
+
+CREATE TABLE movie_theaters (
+  movie_id VARCHAR(26) REFERENCES movies(movie_id),
+  theater_id VARCHAR(26) REFERENCES theaters(theater_id),
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (movie_id, theater_id)
+);
+
+CREATE INDEX idx_movie_theaters_theater_id ON movie_theaters(theater_id); 

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -240,3 +240,62 @@ SELECT u.*
 FROM users u
 JOIN user_roles ur ON u.user_id = ur.user_id
 WHERE ur.role_id = :role-id AND u.deleted_at IS NULL;
+
+-- 극장 관련 쿼리
+-- :name save-theater! :! :n
+-- :doc 새로운 극장을 생성합니다
+INSERT INTO theaters (theater_id, uuid, chain_type, created_at, updated_at)
+VALUES (:theater_id, :uuid, :chain_type, :created_at, :updated_at)
+RETURNING theater_id, uuid, chain_type, created_at;
+
+-- :name get-theater-by-id :? :1
+-- :doc ID로 극장을 조회합니다 (내부용)
+SELECT theater_id, uuid, chain_type, created_at, updated_at
+FROM theaters
+WHERE theater_id = :theater_id;
+
+-- :name get-theater-by-uuid :? :1
+-- :doc UUID로 극장을 조회합니다 (외부용)
+SELECT theater_id, uuid, chain_type, created_at, updated_at
+FROM theaters
+WHERE uuid = :uuid;
+
+-- :name find-theaters-by-chain-type :? :*
+-- :doc 체인 타입으로 극장들을 조회합니다
+SELECT theater_id, uuid, chain_type, created_at, updated_at
+FROM theaters
+WHERE chain_type = :chain_type;
+
+-- 영화-극장 관계 쿼리
+-- :name save-movie-theater! :! :n
+-- :doc 영화-극장 관계를 저장합니다
+INSERT INTO movie_theaters (movie_id, theater_id, created_at)
+VALUES (:movie_id, :theater_id, :created_at)
+RETURNING movie_id, theater_id, created_at;
+
+-- :name get-theaters-by-movie :? :*
+-- :doc 영화의 상영 극장 목록을 조회합니다
+SELECT t.*
+FROM theaters t
+JOIN movie_theaters mt ON t.theater_id = mt.theater_id
+WHERE mt.movie_id = :movie_id;
+
+-- :name get-theaters-by-movies :? :*
+-- :doc 여러 영화의 상영 극장 목록을 한 번에 조회합니다 (N+1 방지)
+SELECT t.*, mt.movie_id
+FROM theaters t
+JOIN movie_theaters mt ON t.theater_id = mt.theater_id
+WHERE mt.movie_id = ANY(:movie_ids::varchar[]);
+
+-- :name get-movies-by-theater :? :*
+-- :doc 극장의 상영 영화 목록을 조회합니다
+SELECT m.*
+FROM movies m
+JOIN movie_theaters mt ON m.movie_id = mt.movie_id
+WHERE mt.theater_id = :theater_id
+  AND m.deleted_at IS NULL;
+
+-- :name delete-movie-theater! :! :n
+-- :doc 영화-극장 관계를 삭제합니다
+DELETE FROM movie_theaters
+WHERE movie_id = :movie_id AND theater_id = :theater_id;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -299,3 +299,9 @@ WHERE mt.theater_id = :theater_id
 -- :doc 영화-극장 관계를 삭제합니다
 DELETE FROM movie_theaters
 WHERE movie_id = :movie_id AND theater_id = :theater_id;
+
+-- :name get-theater-by-name :? :1
+-- :doc 이름으로 극장을 조회합니다
+SELECT theater_id, uuid, chain_type, created_at, updated_at
+FROM theaters
+WHERE theater_name = :theater_name;

--- a/resources/system.edn
+++ b/resources/system.edn
@@ -210,6 +210,7 @@
  {:movie-repository #ig/ref :infrastructure/movie-repository
   :movie-actor-repository #ig/ref :infrastructure/movie-actor-repository
   :movie-director-repository #ig/ref :infrastructure/movie-director-repository
+  :movie-theater-repository #ig/ref :infrastructure/movie-theater-repository
   :tx-manager #ig/ref :db/tx-manager}
 
 

--- a/resources/system.edn
+++ b/resources/system.edn
@@ -141,6 +141,16 @@
   :tx-manager #ig/ref :db/tx-manager
   :queries #ig/ref :db.sql/queries}
 
+ :infrastructure/theater-repository
+ {:datasource #ig/ref :db.sql/connection
+  :tx-manager #ig/ref :db/tx-manager
+  :queries #ig/ref :db.sql/queries}
+
+ :infrastructure/movie-theater-repository
+ {:datasource #ig/ref :db.sql/connection
+  :tx-manager #ig/ref :db/tx-manager
+  :queries #ig/ref :db.sql/queries}
+
  :infrastructure/email-verification-gateway
  {:secret #or [#env EMAIL_VERIFICATION_SECRET "VERIFICATION_SECRET_HERE"]}
 
@@ -183,17 +193,18 @@
   :role-request-repository #ig/ref :infrastructure/role-request-repository
   :event-publisher #ig/ref :infrastructure/event-bus}
 
- :domain/movie-use-case
- {:with-tx #ig/ref :db/tx-manager
-  :movie-repository #ig/ref :infrastructure/movie-repository
-  :actor-repository #ig/ref :infrastructure/actor-repository
-  :movie-actor-repository #ig/ref :infrastructure/movie-actor-repository
-  :movie-director-repository #ig/ref :infrastructure/movie-director-repository
-  :director-repository #ig/ref :infrastructure/director-repository
-  :event-publisher #ig/ref :infrastructure/event-bus
-  :id-generator #ig/ref :infrastructure/ulid-generator
-  :uuid-generator #ig/ref :infrastructure/uuid-generator
-  :image-gateway #ig/ref :infrastructure/cloudinary-storage}
+:domain/movie-use-case
+{:with-tx #ig/ref :db/tx-manager
+ :movie-repository #ig/ref :infrastructure/movie-repository
+ :movie-director-repository #ig/ref :infrastructure/movie-director-repository
+ :movie-actor-repository #ig/ref :infrastructure/movie-actor-repository
+ :movie-theater-repository #ig/ref :infrastructure/movie-theater-repository
+ :theater-repository #ig/ref :infrastructure/theater-repository
+ :director-repository #ig/ref :infrastructure/director-repository
+ :actor-repository #ig/ref :infrastructure/actor-repository
+ :image-gateway #ig/ref :infrastructure/cloudinary-storage
+ :id-generator #ig/ref :infrastructure/id-generator
+ :uuid-generator #ig/ref :infrastructure/uuid-generator}
 
  :domain/movie-query-service
  {:movie-repository #ig/ref :infrastructure/movie-repository

--- a/src/clj/kit/spooky_town/core.clj
+++ b/src/clj/kit/spooky_town/core.clj
@@ -34,6 +34,8 @@
    [kit.spooky-town.infrastructure.persistence.director]
    [kit.spooky-town.infrastructure.persistence.movie-director]
    [kit.spooky-town.infrastructure.persistence.movie-actor]
+   [kit.spooky-town.infrastructure.persistence.movie-theater]
+   [kit.spooky-town.infrastructure.persistence.theater]
    [kit.spooky-town.infrastructure.persistence.role]
    [kit.spooky-town.infrastructure.persistence.user-role]
    ;; Use-cases

--- a/src/clj/kit/spooky_town/domain/movie/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie/entity.clj
@@ -45,18 +45,17 @@
       movie)))
 
 ;; 조회용 요약 정보 변환
-(defn ->summary [{:keys [movie-id title poster release-date genres
-                         release-status] :as movie}]
-  (when (and movie-id title poster release-date
-             genres release-status)
-    {:movie-id movie-id
+(defn ->summary [{:keys [movie-uuid title poster  genres
+                         release-info] :as movie}]
+  (when (and movie-uuid title release-info
+             genres)
+    {:movie-uuid movie-uuid
      :title title
-     :poster-url (:url poster)
-     :release-date release-date
+     :poster-url (:url poster) 
      :genres genres
      :director-names (when (:directors movie)
-                      (mapv :name (:directors movie)))
-     :release-status release-status}))
+                       (mapv :name (:directors movie))) 
+     :release-info release-info}))
 
 (defn- update-title [movie new-title]
   (when-let [validated-title (value/create-title new-title)]

--- a/src/clj/kit/spooky_town/domain/movie/query/service.clj
+++ b/src/clj/kit/spooky_town/domain/movie/query/service.clj
@@ -4,14 +4,16 @@
             [kit.spooky-town.domain.movie.repository.protocol :as movie-repo]
             [kit.spooky-town.domain.movie-actor.repository.protocol :as movie-actor-repo]
             [kit.spooky-town.domain.movie-director.repository.protocol :as movie-director-repo] 
+            [kit.spooky-town.domain.movie-theater.repository.protocol :as movie-theater-repo]
             [integrant.core :as ig]))
 
 (defprotocol MovieQueryService
   (find-movie [this params]
     "영화 상세 정보를 조회합니다. 
-     params: {:movie-id string?
+     params: {:movie-uuid string?
               :include-actors boolean?
-              :include-directors boolean?}")
+              :include-directors boolean?
+              :include-theaters boolean?}")
 
   (search-movies [this params]
     "영화 목록을 검색합니다.
@@ -26,23 +28,28 @@
 
   (get-movie-summary [this params]
     "영화 요약 정보를 조회합니다.
-     params: {:movie-id string?}"))
+     params: {:movie-uuid string?}"))
 
 (defrecord MovieQueryServiceImpl [movie-repository 
                                 movie-actor-repository 
                                 movie-director-repository 
+                                movie-theater-repository
                                 with-read-only]
   MovieQueryService
   (find-movie [_ params]
-    (with-read-only [movie-repository movie-actor-repository movie-director-repository]
-      (fn [movie-repo actor-repo director-repo]
-        (when-let [movie (movie-repo/find-by-id movie-repo (:movie-id params))]
-          (cond-> movie
-            (:include-actors params)
-            (assoc :actors (movie-actor-repo/find-actors-by-movie actor-repo (:movie-id params)))
-            
-            (:include-directors params)
-            (assoc :directors (movie-director-repo/find-directors-by-movie director-repo (:movie-id params))))))))
+    (with-read-only [movie-repository movie-actor-repository movie-director-repository movie-theater-repository]
+      (fn [movie-repo actor-repo director-repo movie-theater-repo]
+        (when-let [movie-id (movie-repo/find-id-by-uuid movie-repo (:movie-uuid params))]
+          (when-let [movie (movie-repo/find-by-id movie-repo movie-id)]
+            (cond-> movie
+              (:include-actors params)
+              (assoc :actors (movie-actor-repo/find-actors-by-movie actor-repo movie-id))
+              
+              (:include-directors params)
+              (assoc :directors (movie-director-repo/find-directors-by-movie director-repo movie-id))
+
+              (:include-theaters params)
+              (assoc :theaters (movie-theater-repo/find-theaters-by-movie movie-theater-repo movie-id))))))))
 
   (search-movies [_ params]
     (with-read-only [movie-repository]
@@ -57,13 +64,15 @@
   (get-movie-summary [_ params]
     (with-read-only [movie-repository]
       (fn [repo]
-        (when-let [movie (movie-repo/find-by-id repo (:movie-id params))]
-          (entity/->summary movie))))))
+        (when-let [movie-id (movie-repo/find-id-by-uuid repo (:movie-uuid params))]
+          (when-let [movie (movie-repo/find-by-id repo movie-id)]
+            (entity/->summary movie)))))))
 
 (defmethod ig/init-key :domain/movie-query-service
-  [_ {:keys [movie-repository movie-actor-repository movie-director-repository with-read-only]}]
+  [_ {:keys [movie-repository movie-actor-repository movie-director-repository movie-theater-repository with-read-only]}]
   (->MovieQueryServiceImpl 
     movie-repository 
     movie-actor-repository 
     movie-director-repository 
+    movie-theater-repository
     with-read-only))

--- a/src/clj/kit/spooky_town/domain/movie/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/movie/repository/protocol.clj
@@ -10,6 +10,9 @@
   (find-by-uuid [this uuid]
     "UUID로 영화를 조회합니다.")
 
+  (find-id-by-uuid [this uuid]
+    "UUID로 영화 ID를 조회합니다.")
+
   ;; 새로 추가되는 메서드들
   (find-by-criteria [this criteria]
     "주어진 조건으로 영화 목록을 검색합니다.

--- a/src/clj/kit/spooky_town/domain/movie/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/movie/use_case.clj
@@ -10,123 +10,142 @@
    [kit.spooky-town.domain.movie-director.repository.protocol :as movie-director-repository]
    [kit.spooky-town.domain.movie.entity :as entity]
    [kit.spooky-town.domain.movie.repository.protocol :as movie-repository]
+   [kit.spooky-town.domain.movie-theater.repository.protocol :as movie-theater-repository]
+   [kit.spooky-town.domain.theater.repository.protocol :as theater-repository]
    [kit.spooky-town.domain.movie.value :as value]))
 
-(defprotocol MovieUseCase
-  (create-movie [this command]
-    "새로운 영화를 생성합니다.")
-  (update-movie [this command]
-    "영화 정보를 업데이트합니다."))
 
-(defrecord CreateMovieCommand [title director-names release-info genres movie-actor-infos runtime poster-file])
+  (defprotocol MovieUseCase
+    (create-movie [this command]
+      "새로운 영화를 생성합니다.")
+    (update-movie [this command]
+      "영화 정보를 업데이트합니다."))
 
-(defrecord UpdateMovieCommand [movie-id
-                              title
-                              runtime
-                              genres
-                              release-info
-                              poster-file])
+  (defrecord CreateMovieCommand [title director-infos release-info genres
+                                 movie-actor-infos runtime poster-file
+                                 theater-infos])
 
-(defn- process-poster [image-gateway poster-file]
-  (when poster-file
-    (if-let [validated-file (value/create-poster-file poster-file)]
-      (when-let [uploaded (image-gateway/upload image-gateway validated-file)]
-        (value/create-poster uploaded))
-      (f/fail "유효하지 않은 포스터 파일입니다."))))
+  (defrecord UpdateMovieCommand [movie-id
+                                 title
+                                 runtime
+                                 genres
+                                 release-info
+                                 poster-file])
 
-(defrecord CreateMovieUseCaseImpl [with-tx
-                                   movie-repository
-                                   movie-director-repository
-                                   movie-actor-repository
-                                   director-repository
-                                   actor-repository
-                                   image-gateway
-                                   id-generator
-                                   uuid-generator]
-  MovieUseCase
-  (create-movie [_ {:keys [title director-infos release-info genres
-                          runtime movie-actor-infos poster-file] :as command}]
-    (with-tx movie-repository
-      (fn [repo]
+  (defn- process-poster [image-gateway poster-file]
+    (when poster-file
+      (if-let [validated-file (value/create-poster-file poster-file)]
+        (when-let [uploaded (image-gateway/upload image-gateway validated-file)]
+          (value/create-poster uploaded))
+        (f/fail "유효하지 않은 포스터 파일입니다."))))
+
+  (defrecord CreateMovieUseCaseImpl [with-tx
+                                     movie-repository
+                                     movie-director-repository
+                                     movie-actor-repository
+                                     movie-theater-repository
+                                     director-repository
+                                     actor-repository
+                                     theater-repository
+                                     image-gateway
+                                     id-generator
+                                     uuid-generator]
+    MovieUseCase
+    (create-movie [_ {:keys [title director-infos release-info genres
+                             runtime movie-actor-infos poster-file
+                             theater-infos] :as command}]
+      (with-tx movie-repository
+        (fn [repo]
         ;; 필수 필드 검증
-        (if (and (value/create-title title)
-                 (value/create-director-inputs
-                  (mapv #(hash-map :director-name (:director-name %)
-                                   :director-role (:role %))
-                        director-infos))
-                 (value/create-release-info release-info)
-                 (value/create-genres genres))
+          (if (and (value/create-title title)
+                   (value/create-director-inputs
+                    (mapv #(hash-map :director-name (:director-name %)
+                                     :director-role (:role %))
+                          director-infos))
+                   (value/create-release-info release-info)
+                   (value/create-genres genres))
           ;; 검증 성공 시 기본 필드 추가
-          (let [movie-id (id-generator/generate-ulid id-generator)
-                movie-uuid (id-generator/generate-uuid uuid-generator)
-                created-at (java.util.Date.)
-                updated-at created-at
-                validated-runtime (when runtime
-                                  (value/create-runtime runtime))
-                poster (when poster-file
-                        (when-let [uploaded (image-gateway/upload image-gateway poster-file)]
-                          (value/create-poster uploaded)))]
-            
+            (let [movie-id (id-generator/generate-ulid id-generator)
+                  movie-uuid (id-generator/generate-uuid uuid-generator)
+                  created-at (java.util.Date.)
+                  updated-at created-at
+                  validated-runtime (when runtime
+                                      (value/create-runtime runtime))
+                  poster (when poster-file
+                           (when-let [uploaded (image-gateway/upload image-gateway poster-file)]
+                             (value/create-poster uploaded)))]
+
             ;; 영화 저장
-            (movie-repository/save! repo 
-              (cond-> {:movie-id movie-id
-                      :uuid movie-uuid
-                      :title title
-                      :release-info release-info
-                      :genres genres
-                      :created-at created-at
-                      :updated-at updated-at}
-                
-                validated-runtime
-                (assoc :runtime validated-runtime)
-                
-                poster
-                (assoc :poster poster)))
-            
+              (movie-repository/save! repo
+                                      (cond-> {:movie-id movie-id
+                                               :uuid movie-uuid
+                                               :title title
+                                               :release-info release-info
+                                               :genres genres
+                                               :created-at created-at
+                                               :updated-at updated-at}
+
+                                        validated-runtime
+                                        (assoc :runtime validated-runtime)
+
+                                        poster
+                                        (assoc :poster poster)))
+
             ;; 감독 관계 저장
-            (doseq [{:keys [director-name role]} director-infos]
-              (let [director-id (or
-                                (:director-id (director-repository/find-by-name director-repository director-name))
-                                (:director-id
-                                  (director-repository/save! director-repository
-                                                         {:director-id (id-generator/generate-ulid id-generator)
-                                                          :director-name director-name})))]
-                (movie-director-repository/save-movie-director! movie-director-repository movie-id director-id role)))
-            
+              (doseq [{:keys [director-name role]} director-infos]
+                (let [director-id (or
+                                   (:director-id (director-repository/find-by-name director-repository director-name))
+                                   (:director-id
+                                    (director-repository/save! director-repository
+                                                               {:director-id (id-generator/generate-ulid id-generator)
+                                                                :director-name director-name})))]
+                  (movie-director-repository/save-movie-director! movie-director-repository movie-id director-id role)))
+
             ;; 배우 관계 저장
-            (doseq [{:keys [actor-name role]} movie-actor-infos]
-              (let [actor-id (or
-                             (:actor-id (actor-repository/find-by-name actor-repository actor-name))
-                             (:actor-id
-                               (actor-repository/save! actor-repository
-                                                    {:actor-id (id-generator/generate-ulid id-generator)
-                                                     :actor-name actor-name})))]
-                (movie-actor-repository/save-movie-actor! movie-actor-repository movie-id actor-id role)))
-            
+              (doseq [{:keys [actor-name role]} movie-actor-infos]
+                (let [actor-id (or
+                                (:actor-id (actor-repository/find-by-name actor-repository actor-name))
+                                (:actor-id
+                                 (actor-repository/save! actor-repository
+                                                         {:actor-id (id-generator/generate-ulid id-generator)
+                                                          :actor-name actor-name})))]
+                  (movie-actor-repository/save-movie-actor! movie-actor-repository movie-id actor-id role)))
+
+            ;; 극장 관계 저장
+              (doseq [{:keys [theater-name]} theater-infos]
+                (let [theater-id (or
+                                  (theater-repository/find-id-by-name theater-repository theater-name)
+                                  (:theater-id
+                                   (theater-repository/save! theater-repository
+                                                             {:theater-id (id-generator/generate-ulid id-generator)
+                                                              :theater-name theater-name})))]
+                  (movie-theater-repository/save-movie-theater!
+                   movie-theater-repository movie-id theater-id)))
+
             ;; 생성된 영화 ID 반환
-            movie-id)
+              movie-id)
           ;; 검증 실패 시
-          (f/fail "필수 필드가 유효하지 않습니다.")))))
+            (f/fail "필수 필드가 유효하지 않습니다.")))))
 
-  (update-movie [_ {:keys [movie-id poster-file] :as command}]
-    (with-tx movie-repository
-      (fn [repo]
-        (if-let [movie (movie-repository/find-by-id repo movie-id)]
-          (let [poster-result (process-poster image-gateway poster-file)
-                update-data (cond
-                             (f/failed? poster-result) poster-result
-                             poster-result (-> command
-                                             (assoc :poster poster-result)
-                                             (dissoc :poster-file))
-                             :else (dissoc command :poster-file))]
-            (if (f/failed? update-data)
-              update-data
-              (if-let [updated-movie (entity/update-movie movie update-data)]
-                (do
-                  (movie-repository/save! repo updated-movie)
-                  movie-id)
-                (f/fail "영화 정보 업데이트가 유효하지 않습니다."))))
-          (f/fail "영화를 찾을 수 없습니다."))))))
+    (update-movie [_ {:keys [movie-id poster-file] :as command}]
+      (with-tx movie-repository
+        (fn [repo]
+          (if-let [movie (movie-repository/find-by-id repo movie-id)]
+            (let [poster-result (process-poster image-gateway poster-file)
+                  update-data (cond
+                                (f/failed? poster-result) poster-result
+                                poster-result (-> command
+                                                  (assoc :poster poster-result)
+                                                  (dissoc :poster-file))
+                                :else (dissoc command :poster-file))]
+              (if (f/failed? update-data)
+                update-data
+                (if-let [updated-movie (entity/update-movie movie update-data)]
+                  (do
+                    (movie-repository/save! repo updated-movie)
+                    movie-id)
+                  (f/fail "영화 정보 업데이트가 유효하지 않습니다."))))
+            (f/fail "영화를 찾을 수 없습니다."))))))
 
-(defmethod ig/init-key :domain/movie-use-case [_ {:keys [with-tx movie-repository movie-director-repository movie-actor-repository director-repository actor-repository image-gateway id-generator uuid-generator]}]
-  (->CreateMovieUseCaseImpl with-tx movie-repository movie-director-repository movie-actor-repository director-repository actor-repository image-gateway id-generator uuid-generator))
+  (defmethod ig/init-key :domain/movie-use-case [_ {:keys [with-tx movie-repository movie-director-repository movie-actor-repository movie-theater-repository director-repository actor-repository theater-repository image-gateway id-generator uuid-generator]}]
+    (->CreateMovieUseCaseImpl with-tx movie-repository movie-director-repository movie-actor-repository movie-theater-repository director-repository actor-repository theater-repository image-gateway id-generator uuid-generator))

--- a/src/clj/kit/spooky_town/domain/movie_director/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/movie_director/repository/protocol.clj
@@ -6,4 +6,6 @@
   (find-directors-by-movie [this movie-id]
     "영화 ID로 감독 정보를 조회합니다.")
   (find-movies-by-director [this director-id]
-    "감독 ID로 영화 정보를 조회합니다.")) 
+    "감독 ID로 영화 정보를 조회합니다.")
+  (delete-by-movie-id! [this movie-id]
+    "영화 ID로 감독 정보를 삭제합니다."))

--- a/src/clj/kit/spooky_town/domain/movie_theater/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie_theater/entity.clj
@@ -1,0 +1,26 @@
+(ns kit.spooky-town.domain.movie-theater.entity
+  (:require [clojure.spec.alpha :as s]
+            [kit.spooky-town.domain.movie-theater.value :as value]))
+
+;; 엔티티 스펙
+(s/def ::movie-theater
+  (s/keys :req-un [::value/movie-id
+                   ::value/theater-id
+                   ::value/created-at]))
+
+;; 엔티티 레코드
+(defrecord MovieTheater [movie-id theater-id created-at])
+
+;; 생성 함수
+(defn create-movie-theater [{:keys [movie-id theater-id created-at]
+                            :or {created-at (value/create-timestamp)}}]
+  (let [movie-theater (map->MovieTheater
+                       {:movie-id movie-id
+                        :theater-id theater-id
+                        :created-at created-at})]
+    (when (s/valid? ::movie-theater movie-theater)
+      movie-theater)))
+
+;; 유효성 검사
+(defn valid? [movie-theater]
+  (s/valid? ::movie-theater movie-theater)) 

--- a/src/clj/kit/spooky_town/domain/movie_theater/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/movie_theater/repository/protocol.clj
@@ -1,0 +1,17 @@
+(ns kit.spooky-town.domain.movie-theater.repository.protocol)
+
+(defprotocol MovieTheaterRepository
+  (save-movie-theater! [this movie-id theater-id]
+    "영화-극장 관계를 저장합니다.")
+
+  (find-theaters-by-movie [this movie-id]
+    "영화 ID로 극장들을 조회합니다. N+1 문제를 피하기 위해 한 번의 쿼리로 처리합니다.")
+
+  (find-theaters-by-movies [this movie-ids]
+    "여러 영화 ID로 극장들을 조회합니다. 벌크 조회를 통해 N+1 문제를 방지합니다.")
+
+  (find-movies-by-theater [this theater-id]
+    "극장 ID로 영화들을 조회합니다.")
+
+  (delete-movie-theater! [this movie-id theater-id]
+    "영화-극장 관계를 삭제합니다.")) 

--- a/src/clj/kit/spooky_town/domain/movie_theater/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/movie_theater/use_case.clj
@@ -1,0 +1,47 @@
+(ns kit.spooky-town.domain.movie-theater.use-case
+  (:require [kit.spooky-town.domain.movie-theater.entity :as entity]
+            [kit.spooky-town.domain.movie-theater.repository.protocol :as movie-theater-repo]
+            [integrant.core :as ig]))
+
+(defprotocol MovieTheaterUseCase
+  (assign-theater! [this command]
+    "영화에 극장을 할당합니다.
+     command: {:movie-id string?
+               :theater-id string?}")
+
+  (remove-theater! [this command]
+    "영화에서 극장을 제거합니다.
+     command: {:movie-id string?
+               :theater-id string?}")
+
+  (get-theaters [this command]
+    "영화의 극장 목록을 조회합니다.
+     command: {:movie-id string?}")
+
+  (get-movies [this command]
+    "극장의 영화 목록을 조회합니다.
+     command: {:theater-id string?}"))
+
+(defrecord MovieTheaterUseCaseImpl [movie-theater-repository with-tx]
+  MovieTheaterUseCase
+  (assign-theater! [_ command]
+    (with-tx [movie-theater-repository]
+      (fn [repo]
+        (let [{:keys [movie-id theater-id]} command]
+          (movie-theater-repo/save-movie-theater! repo movie-id theater-id)))))
+
+  (remove-theater! [_ command]
+    (with-tx [movie-theater-repository]
+      (fn [repo]
+        (let [{:keys [movie-id theater-id]} command]
+          (movie-theater-repo/delete-movie-theater! repo movie-id theater-id)))))
+
+  (get-theaters [_ command]
+    (movie-theater-repo/find-theaters-by-movie movie-theater-repository (:movie-id command)))
+
+  (get-movies [_ command]
+    (movie-theater-repo/find-movies-by-theater movie-theater-repository (:theater-id command))))
+
+(defmethod ig/init-key :domain/movie-theater-use-case
+  [_ {:keys [movie-theater-repository with-tx]}]
+  (->MovieTheaterUseCaseImpl movie-theater-repository with-tx)) 

--- a/src/clj/kit/spooky_town/domain/movie_theater/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie_theater/value.clj
@@ -1,0 +1,14 @@
+(ns kit.spooky-town.domain.movie-theater.value
+  (:require [clojure.spec.alpha :as s]))
+
+;; ID 값 객체
+(s/def ::movie-id string?)
+(s/def ::theater-id string?)
+
+;; 타임스탬프
+(s/def ::created-at inst?)
+(s/def ::updated-at inst?)
+
+;; 값 객체 생성 함수
+(defn create-timestamp []
+  (java.util.Date.)) 

--- a/src/clj/kit/spooky_town/domain/theater/entity.clj
+++ b/src/clj/kit/spooky_town/domain/theater/entity.clj
@@ -40,4 +40,13 @@
 
 ;; 유효성 검사
 (defn valid? [theater]
-  (s/valid? ::theater theater)) 
+  (s/valid? ::theater theater))
+
+;; 업데이트 함수
+(defn update-theater [theater {:keys [chain-type]}]
+  (when-let [validated-chain (value/create-chain-type chain-type)]
+    (let [updated-theater (assoc theater
+                                :chain-type validated-chain
+                                :updated-at (value/create-timestamp))]
+      (when (valid? updated-theater)
+        updated-theater)))) 

--- a/src/clj/kit/spooky_town/domain/theater/entity.clj
+++ b/src/clj/kit/spooky_town/domain/theater/entity.clj
@@ -1,0 +1,43 @@
+(ns kit.spooky-town.domain.theater.entity
+  (:require [clojure.spec.alpha :as s]
+            [kit.spooky-town.domain.theater.value :as value]))
+
+;; 엔티티 스펙
+(s/def ::theater
+  (s/keys :req-un [::value/theater-id
+                   ::value/uuid
+                   ::value/chain-type
+                   ::value/created-at
+                   ::value/updated-at]))
+
+;; 엔티티 레코드
+(defrecord Theater [theater-id
+                    uuid
+                    chain-type
+                    created-at
+                    updated-at])
+
+;; 생성 함수
+(defn create-theater [{:keys [theater-id
+                              uuid
+                              chain-type
+                              created-at]
+                       :or {created-at (value/create-timestamp)}}]
+  (when-let [validated-chain (value/create-chain-type chain-type)]
+    (let [theater (map->Theater
+                   {:theater-id theater-id
+                    :uuid uuid
+                    :chain-type validated-chain
+                    :created-at created-at
+                    :updated-at created-at})]
+      (when (s/valid? ::theater theater)
+        theater))))
+
+;; 요약 정보 변환
+(defn ->summary [{:keys [uuid chain-type]}]
+  {:uuid uuid
+   :chain-name (value/chain-type->str chain-type)})
+
+;; 유효성 검사
+(defn valid? [theater]
+  (s/valid? ::theater theater)) 

--- a/src/clj/kit/spooky_town/domain/theater/query/service.clj
+++ b/src/clj/kit/spooky_town/domain/theater/query/service.clj
@@ -1,0 +1,39 @@
+(ns kit.spooky-town.domain.theater.query.service
+  (:require [kit.spooky-town.domain.theater.entity :as entity]
+            [kit.spooky-town.domain.theater.repository.protocol :as theater-repo]
+            [integrant.core :as ig]))
+
+(defprotocol TheaterQueryService
+  (find-theater [this params]
+    "극장 상세 정보를 조회합니다.
+     params: {:theater-uuid uuid?}")
+
+  (search-theaters [this params]
+    "극장 목록을 검색합니다.
+     params: {:chain-type keyword?}")
+
+  (get-theater-summary [this params]
+    "극장 요약 정보를 조회합니다.
+     params: {:theater-uuid uuid?}"))
+
+(defrecord TheaterQueryServiceImpl [theater-repository with-read-only]
+  TheaterQueryService
+  (find-theater [_ params]
+    (with-read-only [theater-repository]
+      (fn [repo]
+        (theater-repo/find-by-uuid repo (:theater-uuid params)))))
+
+  (search-theaters [_ params]
+    (with-read-only [theater-repository]
+      (fn [repo]
+        (theater-repo/find-by-chain-type repo (:chain-type params)))))
+
+  (get-theater-summary [_ params]
+    (with-read-only [theater-repository]
+      (fn [repo]
+        (when-let [theater (theater-repo/find-by-uuid repo (:theater-uuid params))]
+          (entity/->summary theater))))))
+
+(defmethod ig/init-key :domain/theater-query-service
+  [_ {:keys [theater-repository with-read-only]}]
+  (->TheaterQueryServiceImpl theater-repository with-read-only)) 

--- a/src/clj/kit/spooky_town/domain/theater/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/theater/repository/protocol.clj
@@ -14,4 +14,7 @@
     "UUID로 극장의 ULID를 조회합니다.")
 
   (find-by-chain-type [this chain-type]
-    "체인 타입으로 극장들을 조회합니다.")) 
+    "체인 타입으로 극장들을 조회합니다.")
+
+  (delete! [this theater]
+    "극장을 삭제합니다.")) 

--- a/src/clj/kit/spooky_town/domain/theater/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/theater/repository/protocol.clj
@@ -1,0 +1,17 @@
+(ns kit.spooky-town.domain.theater.repository.protocol)
+
+(defprotocol TheaterRepository
+  (save! [this theater]
+    "극장을 저장합니다.")
+
+  (find-by-id [this theater-id]
+    "ULID로 극장을 조회합니다.")
+
+  (find-by-uuid [this uuid]
+    "UUID로 극장을 조회합니다.")
+
+  (find-id-by-uuid [this uuid]
+    "UUID로 극장의 ULID를 조회합니다.")
+
+  (find-by-chain-type [this chain-type]
+    "체인 타입으로 극장들을 조회합니다.")) 

--- a/src/clj/kit/spooky_town/domain/theater/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/theater/repository/protocol.clj
@@ -16,5 +16,8 @@
   (find-by-chain-type [this chain-type]
     "체인 타입으로 극장들을 조회합니다.")
 
+  (find-id-by-name [this name]
+    "이름으로 극장을 조회합니다.")
+
   (delete! [this theater]
     "극장을 삭제합니다.")) 

--- a/src/clj/kit/spooky_town/domain/theater/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/theater/use_case.clj
@@ -1,0 +1,49 @@
+(ns kit.spooky-town.domain.theater.use-case
+  (:require [kit.spooky-town.domain.theater.entity :as entity]
+            [kit.spooky-town.domain.common.id.protocol :as id-generator]
+            [kit.spooky-town.domain.theater.repository.protocol :as theater-repo]
+            [integrant.core :as ig]))
+
+(defprotocol TheaterUseCase
+  (create-theater! [this command]
+    "새로운 극장을 생성합니다.
+     command: {:chain-type keyword?}")
+
+  (update-theater! [this command]
+    "극장 정보를 수정합니다.
+     command: {:theater-uuid uuid?
+               :chain-type keyword?}")
+
+  (delete-theater! [this command]
+    "극장을 삭제합니다.
+     command: {:theater-uuid uuid?}"))
+
+(defrecord TheaterUseCaseImpl [theater-repository id-generator uuid-generator with-tx]
+  TheaterUseCase
+  (create-theater! [_ command]
+    (with-tx [theater-repository]
+      (fn [repo]
+        (when-let [theater (entity/create-theater
+                            {:theater-id (id-generator/generate-ulid id-generator)
+                             :uuid (id-generator/generate-uuid uuid-generator)
+                             :chain-type (:chain-type command)})]
+          (theater-repo/save! repo theater)))))
+
+  (update-theater! [_ command]
+    (with-tx [theater-repository]
+      (fn [repo]
+        (when-let [theater (theater-repo/find-by-uuid repo (:theater-uuid command))]
+          (when-let [updated-theater (entity/update-theater
+                                     theater
+                                     {:chain-type (:chain-type command)})]
+            (theater-repo/save! repo updated-theater))))))
+
+  (delete-theater! [_ command]
+    (with-tx [theater-repository]
+      (fn [repo]
+        (when-let [theater (theater-repo/find-by-uuid repo (:theater-uuid command))]
+          (theater-repo/delete! repo theater))))))
+
+(defmethod ig/init-key :domain/theater-use-case
+  [_ {:keys [theater-repository id-generator uuid-generator with-tx]}]
+  (->TheaterUseCaseImpl theater-repository id-generator uuid-generator with-tx)) 

--- a/src/clj/kit/spooky_town/domain/theater/value.clj
+++ b/src/clj/kit/spooky_town/domain/theater/value.clj
@@ -1,0 +1,30 @@
+(ns kit.spooky-town.domain.theater.value
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+;; ID 값 객체
+(s/def ::theater-id (s/and string? #(not (str/blank? %))))
+(s/def ::uuid uuid?)
+
+;; 극장 체인 값 객체 (영화 배급사)
+(s/def ::chain-type #{:cgv :megabox :lotte})
+
+;; 타임스탬프
+(s/def ::created-at inst?)
+(s/def ::updated-at inst?)
+
+;; 값 객체 생성 함수들
+(defn create-chain-type [chain]
+  (when (s/valid? ::chain-type chain)
+    chain))
+
+(defn create-timestamp []
+  (java.util.Date.))
+
+;; 유틸리티 함수
+(defn chain-type->str [chain-type]
+  (case chain-type
+    :cgv "CGV"
+    :megabox "메가박스"
+    :lotte "롯데시네마"
+    "알 수 없음")) 

--- a/src/clj/kit/spooky_town/infrastructure/persistence/movie_theater.clj
+++ b/src/clj/kit/spooky_town/infrastructure/persistence/movie_theater.clj
@@ -1,0 +1,58 @@
+(ns kit.spooky-town.infrastructure.persistence.movie-theater
+  (:require [kit.spooky-town.domain.movie-theater.repository.protocol :as protocol]
+            [kit.spooky-town.infrastructure.persistence.transaction :refer [UpdateQueryFn]]
+            [integrant.core :as ig]
+            [next.jdbc.result-set :as rs]))
+
+(defrecord MovieTheaterRepository [datasource tx-manager queries]
+  UpdateQueryFn
+  (update-query-fn [this tx-fn]
+    (assoc this :query-fn tx-fn))
+
+  protocol/MovieTheaterRepository
+  (save-movie-theater! [this movie-id theater-id]
+    (.with-tx tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:save-movie-theater! queries)
+                   {:movie_id movie-id
+                    :theater_id theater-id
+                    :created_at (java.util.Date.)}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-theaters-by-movie [this movie-id]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:get-theaters-by-movie queries)
+                   {:movie_id movie-id}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-theaters-by-movies [this movie-ids]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:get-theaters-by-movies queries)
+                   {:movie_ids movie-ids}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-movies-by-theater [this theater-id]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:get-movies-by-theater queries)
+                   {:theater_id theater-id}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (delete-movie-theater! [this movie-id theater-id]
+    (.with-tx tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:delete-movie-theater! queries)
+                   {:movie_id movie-id
+                    :theater_id theater-id}
+                   {:builder-fn rs/as-unqualified-maps}))))))
+
+(defmethod ig/init-key :infrastructure/movie-theater-repository
+  [_ {:keys [datasource tx-manager queries]}]
+  (->MovieTheaterRepository datasource tx-manager queries)) 

--- a/src/clj/kit/spooky_town/infrastructure/persistence/theater.clj
+++ b/src/clj/kit/spooky_town/infrastructure/persistence/theater.clj
@@ -51,7 +51,7 @@
                                    {:chain_type (name chain-type)}
                                    {:builder-fn rs/as-unqualified-maps})))))
 
-  (find-by-name [this theater-name]
+  (find-id-by-name [this theater-name]
     (.with-read-only tx-manager [this]
                      (fn [repo]
                        (let [query-fn (:query-fn repo)]

--- a/src/clj/kit/spooky_town/infrastructure/persistence/theater.clj
+++ b/src/clj/kit/spooky_town/infrastructure/persistence/theater.clj
@@ -12,44 +12,52 @@
   protocol/TheaterRepository
   (save! [this theater]
     (.with-tx tx-manager [this]
-      (fn [repo]
-        (let [query-fn (:query-fn repo)]
-          (query-fn (:save-theater! queries)
-                   theater
-                   {:builder-fn rs/as-unqualified-maps})))))
+              (fn [repo]
+                (let [query-fn (:query-fn repo)]
+                  (query-fn (:save-theater! queries)
+                            theater
+                            {:builder-fn rs/as-unqualified-maps})))))
 
   (find-by-id [this theater-id]
     (.with-read-only tx-manager [this]
-      (fn [repo]
-        (let [query-fn (:query-fn repo)]
-          (query-fn (:get-theater-by-id queries)
-                   {:theater_id theater-id}
-                   {:builder-fn rs/as-unqualified-maps})))))
+                     (fn [repo]
+                       (let [query-fn (:query-fn repo)]
+                         (query-fn (:get-theater-by-id queries)
+                                   {:theater_id theater-id}
+                                   {:builder-fn rs/as-unqualified-maps})))))
 
   (find-by-uuid [this uuid]
     (.with-read-only tx-manager [this]
-      (fn [repo]
-        (let [query-fn (:query-fn repo)]
-          (query-fn (:get-theater-by-uuid queries)
-                   {:uuid uuid}
-                   {:builder-fn rs/as-unqualified-maps})))))
+                     (fn [repo]
+                       (let [query-fn (:query-fn repo)]
+                         (query-fn (:get-theater-by-uuid queries)
+                                   {:uuid uuid}
+                                   {:builder-fn rs/as-unqualified-maps})))))
 
   (find-id-by-uuid [this uuid]
     (.with-read-only tx-manager [this]
-      (fn [repo]
-        (let [query-fn (:query-fn repo)
-              result (query-fn (:get-theater-by-uuid queries)
-                              {:uuid uuid}
-                              {:builder-fn rs/as-unqualified-maps})]
-          (:theater_id result)))))
+                     (fn [repo]
+                       (let [query-fn (:query-fn repo)
+                             result (query-fn (:get-theater-by-uuid queries)
+                                              {:uuid uuid}
+                                              {:builder-fn rs/as-unqualified-maps})]
+                         (:theater_id result)))))
 
   (find-by-chain-type [this chain-type]
     (.with-read-only tx-manager [this]
-      (fn [repo]
-        (let [query-fn (:query-fn repo)]
-          (query-fn (:find-theaters-by-chain-type queries)
-                   {:chain_type (name chain-type)}
-                   {:builder-fn rs/as-unqualified-maps}))))))
+                     (fn [repo]
+                       (let [query-fn (:query-fn repo)]
+                         (query-fn (:find-theaters-by-chain-type queries)
+                                   {:chain_type (name chain-type)}
+                                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-by-name [this theater-name]
+    (.with-read-only tx-manager [this]
+                     (fn [repo]
+                       (let [query-fn (:query-fn repo)]
+                         (query-fn (:get-theater-by-name queries)
+                                   {:theater_name theater-name}
+                                   {:builder-fn rs/as-unqualified-maps}))))))
 
 (defmethod ig/init-key :infrastructure/theater-repository
   [_ {:keys [datasource tx-manager queries]}]

--- a/src/clj/kit/spooky_town/infrastructure/persistence/theater.clj
+++ b/src/clj/kit/spooky_town/infrastructure/persistence/theater.clj
@@ -1,0 +1,56 @@
+(ns kit.spooky-town.infrastructure.persistence.theater
+  (:require [kit.spooky-town.domain.theater.repository.protocol :as protocol]
+            [kit.spooky-town.infrastructure.persistence.transaction :refer [UpdateQueryFn]]
+            [integrant.core :as ig]
+            [next.jdbc.result-set :as rs]))
+
+(defrecord TheaterRepository [datasource tx-manager queries]
+  UpdateQueryFn
+  (update-query-fn [this tx-fn]
+    (assoc this :query-fn tx-fn))
+
+  protocol/TheaterRepository
+  (save! [this theater]
+    (.with-tx tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:save-theater! queries)
+                   theater
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-by-id [this theater-id]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:get-theater-by-id queries)
+                   {:theater_id theater-id}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-by-uuid [this uuid]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:get-theater-by-uuid queries)
+                   {:uuid uuid}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-id-by-uuid [this uuid]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)
+              result (query-fn (:get-theater-by-uuid queries)
+                              {:uuid uuid}
+                              {:builder-fn rs/as-unqualified-maps})]
+          (:theater_id result)))))
+
+  (find-by-chain-type [this chain-type]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:find-theaters-by-chain-type queries)
+                   {:chain_type (name chain-type)}
+                   {:builder-fn rs/as-unqualified-maps}))))))
+
+(defmethod ig/init-key :infrastructure/theater-repository
+  [_ {:keys [datasource tx-manager queries]}]
+  (->TheaterRepository datasource tx-manager queries)) 

--- a/src/clj/kit/spooky_town/web/routes/movie.clj
+++ b/src/clj/kit/spooky_town/web/routes/movie.clj
@@ -13,8 +13,15 @@
                   :parameters {:body [:map
                                     [:title string?]
                                     [:description {:optional true} string?]
-                                    [:release_date string?]]}
-                  :responses {201 {:body [:map [:movie-id string?]]}
+                                    [:release-info [:map
+                                                  [:release-date string?]
+                                                  [:release-status {:optional true} keyword?]]]
+                                    [:genres {:optional true} set?]
+                                    [:runtime {:optional true} pos-int?]
+                                    [:actor-ids {:optional true} [:set string?]]
+                                    [:director-ids {:optional true} [:set string?]]
+                                    [:theater-ids {:optional true} [:set string?]]]}
+                  :responses {201 {:body [:map [:movie-uuid string?]]}
                              400 {:body [:map [:error string?]]}}
                   :handler movie/create-movie}
             
@@ -35,37 +42,67 @@
                                         [:total-pages pos-int?]]}}
                   :handler movie/search-movies}})]
    
-   ["/:movie-id"
+   ["/:movie-uuid"
     (merge authenticated-route-data
            {:get {:summary "Get movie details"
-                  :parameters {:path [:map [:movie-id string?]]
+                  :parameters {:path [:map [:movie-uuid string?]]
                              :query [:map
                                     [:include-actors {:optional true} boolean?]
-                                    [:include-directors {:optional true} boolean?]]}
-                  :responses {200 {:body map?}
-                             404 {:body empty?}}
+                                    [:include-directors {:optional true} boolean?]
+                                    [:include-theaters {:optional true} boolean?]]}
+                  :responses {200 {:body [:map
+                                        [:movie-uuid string?]
+                                        [:title string?]
+                                        [:description {:optional true} string?]
+                                        [:poster {:optional true} [:map
+                                                                 [:url string?]]]
+                                        [:release-info [:map
+                                                      [:release-date string?]
+                                                      [:release-status keyword?]]]
+                                        [:genres set?]
+                                        [:runtime {:optional true} pos-int?]
+                                        [:actors {:optional true} 
+                                                [:vector [:map
+                                                         [:actor-uuid string?]
+                                                         [:name string?]]]]
+                                        [:directors {:optional true} 
+                                                   [:vector [:map
+                                                            [:director-uuid string?]
+                                                            [:name string?]]]]
+                                        [:theaters {:optional true}
+                                                  [:vector [:map
+                                                           [:theater-uuid string?]
+                                                           [:name string?]
+                                                           [:chain-type keyword?]]]]]}
+                          404 {:body empty?}}
                   :handler movie/find-movie}
             
             :put {:summary "Update movie"
                   :middleware [wrap-multipart-params]
-                  :parameters {:path [:map [:movie-id string?]]
+                  :parameters {:path [:map [:movie-uuid string?]]
                              :multipart [:map
                                        [:poster {:optional true} any?]]
                              :form [:map
                                    [:title {:optional true} string?]
+                                   [:description {:optional true} string?]
                                    [:runtime {:optional true} pos-int?]
                                    [:genres {:optional true} set?]
-                                   [:release-info {:optional true} map?]]}
-                  :responses {200 {:body [:map [:movie-id string?]]}
+                                   [:release-info {:optional true} [:map
+                                                                  [:release-date string?]
+                                                                  [:release-status keyword?]]]
+                                   [:actor-ids {:optional true} [:set string?]]
+                                   [:director-ids {:optional true} [:set string?]]
+                                   [:theater-ids {:optional true} [:set string?]]]}
+                  :responses {200 {:body [:map [:movie-uuid string?]]}
                              400 {:body [:map [:error string?]]}
                              404 {:body empty?}}
                   :handler movie/update-movie}})]
    
-   ["/:movie-id/summary"
+   ["/:movie-uuid/summary"
     {:get {:summary "Get movie summary"
-           :parameters {:path [:map [:movie-id string?]]}
+           :parameters {:path [:map [:movie-uuid string?]]}
            :responses {200 {:body [:map
-                                 [:movie-id string?]
+                                 [:movie-uuid string?]
                                  [:title string?]
                                  [:poster-url string?]
                                  [:release-date string?]

--- a/test/clj/kit/spooky_town/domain/movie/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/entity_test.clj
@@ -59,29 +59,27 @@
 
 (deftest movie-summary-test
   (testing "영화 엔티티를 요약 정보로 변환"
-    (let [movie {:movie-id "MOVIE123"
-                 :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+    (let [movie {:movie-uuid "550e8400-e29b-41d4-a716-446655440000"
                  :title "스크림"
                  :poster {:url "http://example.com/poster.jpg"}
-                 :release-date "2024-01-01"
+                 :release-info {:status :released
+                                :release-date "2024-01-01"}
                  :genres #{:horror :thriller}
                  :directors [{:name "웨스 크레이븐"}]
-                 :release-status :released
                  :created-at (java.util.Date.)
                  :updated-at (java.util.Date.)}
           summary (entity/->summary movie)]
       
       (testing "필수 필드 포함 여부"
-        (is (= "MOVIE123" (:movie-id summary)))
+        (is (= "550e8400-e29b-41d4-a716-446655440000" (:movie-uuid summary)))
         (is (= "스크림" (:title summary)))
-        (is (= "http://example.com/poster.jpg" (:poster-url summary)))
-        (is (= "2024-01-01" (:release-date summary)))
+        (is (= "http://example.com/poster.jpg" (:poster-url summary))) 
         (is (= #{:horror :thriller} (:genres summary)))
         (is (= ["웨스 크레이븐"] (:director-names summary)))
-        (is (= :released (:release-status summary))))
+        (is (= {:status :released :release-date "2024-01-01"} (:release-info summary))))
       
       (testing "불필요한 필드 제외 여부"
-        (is (nil? (:uuid summary)))
+        (is (nil? (:movie-id summary)))
         (is (nil? (:created-at summary)))
         (is (nil? (:updated-at summary))))))
 

--- a/test/clj/kit/spooky_town/domain/movie/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/movie/test/repository.clj
@@ -16,10 +16,14 @@
 (defn count-by-criteria [_ _]
   (throw (ex-info "Not implemented" {})))
 
+(defn find-id-by-uuid [_ _]
+  (throw (ex-info "Not implemented" {})))
+
 (defrecord TestMovieRepository []
   MovieRepository
   (save! [this movie] (save! this movie))
   (find-by-id [this id] (find-by-id this id))
   (find-by-uuid [this uuid] (find-by-uuid this uuid))
   (find-by-criteria [this criteria] (find-by-criteria this criteria))
-  (count-by-criteria [this criteria] (count-by-criteria this criteria))) 
+  (count-by-criteria [this criteria] (count-by-criteria this criteria))
+  (find-id-by-uuid [this uuid] (find-id-by-uuid this uuid))) 

--- a/test/clj/kit/spooky_town/domain/movie/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/use_case_test.clj
@@ -99,20 +99,19 @@
 
     (testing "영화 생성 실패 - 필수 필드 누락"
       (testing "제목 누락"
-        (let [command (dissoc base-command :title)]
-          (is (f/failed? (use-case/create-movie movie-use-case command)))))
-
-      (testing "감독 정보 누락"
-        (let [command (dissoc base-command :director-infos)]
-          (is (f/failed? (use-case/create-movie movie-use-case command)))))
+        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")]
+          (let [command (dissoc base-command :title)]
+            (is (f/failed? (use-case/create-movie movie-use-case command)))))) 
 
       (testing "개봉 정보 누락"
-        (let [command (dissoc base-command :release-info)]
-          (is (f/failed? (use-case/create-movie movie-use-case command)))))
+        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")]
+          (let [command (dissoc base-command :release-info)]
+            (is (f/failed? (use-case/create-movie movie-use-case command))))))
 
       (testing "장르 누락"
-        (let [command (dissoc base-command :genres)]
-          (is (f/failed? (use-case/create-movie movie-use-case command))))))))
+        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")]
+          (let [command (dissoc base-command :genres)]
+            (is (f/failed? (use-case/create-movie movie-use-case command)))))))))
 
 (deftest update-movie-test
   (let [with-tx (fn [repo f] (f repo))

--- a/test/clj/kit/spooky_town/domain/movie_director/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/movie_director/test/repository.clj
@@ -10,6 +10,9 @@
 (defn find-movies-by-director [_ _]
   (throw (ex-info "Not implemented" {})))
 
+(defn delete-by-movie-id! [_ _]
+  (throw (ex-info "Not implemented" {})))
+
 (defrecord TestMovieDirectorRepository []
   MovieDirectorRepository
   (save-movie-director! [this movie-id director-id role] 
@@ -17,4 +20,6 @@
   (find-directors-by-movie [this movie-id] 
     (find-directors-by-movie this movie-id))
   (find-movies-by-director [this director-id] 
-    (find-movies-by-director this director-id))) 
+    (find-movies-by-director this director-id))
+  (delete-by-movie-id! [this movie-id]
+    (delete-by-movie-id! this movie-id))) 

--- a/test/clj/kit/spooky_town/domain/movie_theater/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie_theater/entity_test.clj
@@ -1,0 +1,39 @@
+(ns kit.spooky-town.domain.movie-theater.entity-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.movie-theater.entity :as entity]
+            [kit.spooky-town.domain.movie-theater.value :as value]))
+
+(deftest create-movie-theater-test
+  (testing "유효한 데이터로 영화-극장 관계 생성"
+    (let [movie-theater-data {:movie-id "01HQ1234567890ABCDEFGHJKLM"
+                             :theater-id "01HQ1234567890ABCDEFGHJKLN"}
+          movie-theater (entity/create-movie-theater movie-theater-data)]
+      (testing "영화-극장 관계가 성공적으로 생성됨"
+        (is (some? movie-theater))
+        (is (= (:movie-id movie-theater-data) (:movie-id movie-theater)))
+        (is (= (:theater-id movie-theater-data) (:theater-id movie-theater)))
+        (is (instance? java.util.Date (:created-at movie-theater))))))
+
+  (testing "필수 필드 누락 시 생성 실패"
+    (testing "movie-id 누락"
+      (let [invalid-data {:theater-id "01HQ1234567890ABCDEFGHJKLN"}
+            movie-theater (entity/create-movie-theater invalid-data)]
+        (is (nil? movie-theater))))
+
+    (testing "theater-id 누락"
+      (let [invalid-data {:movie-id "01HQ1234567890ABCDEFGHJKLM"}
+            movie-theater (entity/create-movie-theater invalid-data)]
+        (is (nil? movie-theater)))))
+
+  (testing "타임스탬프 자동 생성"
+    (let [movie-theater (entity/create-movie-theater
+                         {:movie-id "01HQ1234567890ABCDEFGHJKLM"
+                          :theater-id "01HQ1234567890ABCDEFGHJKLN"})]
+      (is (instance? java.util.Date (:created-at movie-theater))))))
+
+(deftest movie-theater-validation-test
+  (testing "유효한 영화-극장 관계 검증"
+    (let [movie-theater (entity/create-movie-theater
+                         {:movie-id "01HQ1234567890ABCDEFGHJKLM"
+                          :theater-id "01HQ1234567890ABCDEFGHJKLN"})]
+      (is (entity/valid? movie-theater))))) 

--- a/test/clj/kit/spooky_town/domain/movie_theater/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/movie_theater/test/repository.clj
@@ -1,0 +1,34 @@
+(ns kit.spooky-town.domain.movie-theater.test.repository
+  (:require [kit.spooky-town.domain.movie-theater.repository.protocol :refer [MovieTheaterRepository]]))
+
+(defn save-movie-theater! [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-theaters-by-movie [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-theaters-by-movies [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-movies-by-theater [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn delete-movie-theater! [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestMovieTheaterRepository []
+  MovieTheaterRepository
+  (save-movie-theater! [this movie-id theater-id]
+    (save-movie-theater! this movie-id theater-id))
+  
+  (find-theaters-by-movie [this movie-id]
+    (find-theaters-by-movie this movie-id))
+  
+  (find-theaters-by-movies [this movie-ids]
+    (find-theaters-by-movies this movie-ids))
+  
+  (find-movies-by-theater [this theater-id]
+    (find-movies-by-theater this theater-id))
+  
+  (delete-movie-theater! [this movie-id theater-id]
+    (delete-movie-theater! this movie-id theater-id))) 

--- a/test/clj/kit/spooky_town/domain/movie_theater/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie_theater/use_case_test.clj
@@ -1,0 +1,53 @@
+(ns kit.spooky-town.domain.movie-theater.use-case-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.movie-theater.use-case :as use-case :refer [->MovieTheaterUseCaseImpl]]
+            [kit.spooky-town.domain.movie-theater.test.repository :as movie-theater-repository-fixture :refer [->TestMovieTheaterRepository]]))
+
+(def movie-id "01HQ1234567890ABCDEFGHJKLM")
+(def theater-id "01HQ1234567890ABCDEFGHJKLN")
+
+(deftest movie-theater-use-case-test
+  (let [with-tx (fn [[repo] f] (f repo))
+        movie-theater-repository (->TestMovieTheaterRepository)
+        use-case (->MovieTheaterUseCaseImpl movie-theater-repository with-tx)]
+
+    (testing "영화-극장 할당"
+      (with-redefs [movie-theater-repository-fixture/save-movie-theater!
+                    (fn [_ m-id t-id]
+                      {:movie-id m-id
+                       :theater-id t-id})]
+        (let [command {:movie-id movie-id
+                      :theater-id theater-id}
+              result (use-case/assign-theater! use-case command)]
+          (is (some? result))
+          (is (= movie-id (:movie-id result)))
+          (is (= theater-id (:theater-id result))))))
+
+    (testing "영화-극장 관계 제거"
+      (with-redefs [movie-theater-repository-fixture/delete-movie-theater!
+                    (fn [_ m-id t-id]
+                      (and (= m-id movie-id)
+                           (= t-id theater-id)))]
+        (let [command {:movie-id movie-id
+                      :theater-id theater-id}]
+          (is (true? (use-case/remove-theater! use-case command))))))
+
+    (testing "영화의 극장 목록 조회"
+      (let [theaters [{:theater-id theater-id :name "CGV 강남"}]]
+        (with-redefs [movie-theater-repository-fixture/find-theaters-by-movie
+                      (fn [_ m-id]
+                        (when (= m-id movie-id)
+                          theaters))]
+          (let [command {:movie-id movie-id}
+                result (use-case/get-theaters use-case command)]
+            (is (= theaters result))))))
+
+    (testing "극장의 영화 목록 조회"
+      (let [movies [{:movie-id movie-id :title "스푸키 타운의 비밀"}]]
+        (with-redefs [movie-theater-repository-fixture/find-movies-by-theater
+                      (fn [_ t-id]
+                        (when (= t-id theater-id)
+                          movies))]
+          (let [command {:theater-id theater-id}
+                result (use-case/get-movies use-case command)]
+            (is (= movies result)))))))) 

--- a/test/clj/kit/spooky_town/domain/theater/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/theater/entity_test.clj
@@ -1,0 +1,61 @@
+(ns kit.spooky-town.domain.theater.entity-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.theater.entity :as entity]
+            [kit.spooky-town.domain.theater.value :as value]))
+
+(deftest create-theater-test
+  (testing "유효한 데이터로 극장 생성"
+    (let [theater-data {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                       :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+                       :chain-type :cgv}
+          theater (entity/create-theater theater-data)]
+      (testing "극장이 성공적으로 생성됨"
+        (is (some? theater))
+        (is (= (:theater-id theater-data) (:theater-id theater)))
+        (is (= (:uuid theater-data) (:uuid theater)))
+        (is (= (:chain-type theater-data) (:chain-type theater)))
+        (is (instance? java.util.Date (:created-at theater)))
+        (is (instance? java.util.Date (:updated-at theater))))))
+
+  (testing "잘못된 체인 타입으로 극장 생성 시도"
+    (let [theater-data {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                       :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+                       :chain-type :invalid-chain}
+          theater (entity/create-theater theater-data)]
+      (is (nil? theater))))
+
+  (testing "필수 필드 누락 시 극장 생성 실패"
+    (let [invalid-data {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                       :chain-type :cgv}
+          theater (entity/create-theater invalid-data)]
+      (is (nil? theater)))))
+
+(deftest theater-summary-test
+  (testing "극장 요약 정보 변환"
+    (let [theater (entity/create-theater
+                   {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                    :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+                    :chain-type :cgv})
+          summary (entity/->summary theater)]
+      (testing "요약 정보가 올바르게 생성됨"
+        (is (= (:uuid theater) (:uuid summary)))
+        (is (= "CGV" (:chain-name summary)))))))
+
+(deftest theater-validation-test
+  (testing "유효한 극장 검증"
+    (let [theater (entity/create-theater
+                   {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                    :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+                    :chain-type :cgv})]
+      (is (entity/valid? theater))))
+
+  (testing "각 체인 타입별 극장 생성 검증"
+    (doseq [chain-type [:cgv :megabox :lotte]]
+      (testing (str chain-type " 체인 ��입으로 극장 생성")
+        (let [theater (entity/create-theater
+                       {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                        :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+                        :chain-type chain-type})]
+          (is (some? theater))
+          (is (= chain-type (:chain-type theater)))
+          (is (entity/valid? theater))))))) 

--- a/test/clj/kit/spooky_town/domain/theater/query/service_test.clj
+++ b/test/clj/kit/spooky_town/domain/theater/query/service_test.clj
@@ -1,0 +1,69 @@
+(ns kit.spooky-town.domain.theater.query.service-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.theater.query.service :as sut]
+            [kit.spooky-town.domain.theater.test.repository :refer [->TestTheaterRepository]]
+            [kit.spooky-town.domain.theater.repository.protocol :as repo]))
+
+(def ^:private theater-fixture
+  {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+   :uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+   :chain-type :cgv
+   :created-at (java.util.Date.)
+   :updated-at (java.util.Date.)})
+
+(defn- with-test-theater [f]
+  (with-redefs [repo/find-by-uuid
+                (fn [_ uuid]
+                  (when (= uuid (:uuid theater-fixture))
+                    theater-fixture))
+
+                repo/find-by-chain-type
+                (fn [_ chain-type]
+                  (when (= chain-type :cgv)
+                    [theater-fixture]))]
+    (f)))
+
+(use-fixtures :each with-test-theater)
+
+(deftest theater-query-service-test
+  (let [with-read-only (fn [repository f]
+                         (f repository))
+
+        service (sut/->TheaterQueryServiceImpl
+                 (->TestTheaterRepository)
+                 with-read-only)]
+
+    (testing "극장 상세 정보 조회"
+      (testing "존재하는 극장"
+        (let [result (sut/find-theater service {:theater-uuid (:uuid theater-fixture)})]
+          (is (some? result))
+          (is (= (:uuid theater-fixture) (:uuid result)))
+          (is (= (:chain-type theater-fixture) (:chain-type result)))))
+
+      (testing "존재하지 않는 극장"
+        (is (nil? (sut/find-theater
+                   service
+                   {:theater-uuid #uuid "550e8400-e29b-41d4-a716-446655440001"})))))
+
+    (testing "체인 타입으로 극장 검색"
+      (testing "존재하는 체인 타입"
+        (let [result (sut/search-theaters service {:chain-type :cgv})]
+          (is (= 1 (count result)))
+          (is (= (:uuid theater-fixture) (-> result first :uuid)))
+          (is (= :cgv (-> result first :chain-type)))))
+
+      (testing "존재하지 않는 체인 타입"
+        (let [result (sut/search-theaters service {:chain-type :unknown})]
+          (is (empty? result)))))
+
+    (testing "극장 요약 정보 조회"
+      (testing "존재하는 극장"
+        (let [result (sut/get-theater-summary service {:theater-uuid (:uuid theater-fixture)})]
+          (is (some? result))
+          (is (= (:uuid theater-fixture) (:uuid result)))
+          (is (= "CGV" (:chain-name result)))))
+
+      (testing "존재하지 않는 극장"
+        (is (nil? (sut/get-theater-summary
+                   service
+                   {:theater-uuid #uuid "550e8400-e29b-41d4-a716-446655440001"})))))))

--- a/test/clj/kit/spooky_town/domain/theater/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/theater/test/repository.clj
@@ -1,0 +1,25 @@
+(ns kit.spooky-town.domain.theater.test.repository
+  (:require [kit.spooky-town.domain.theater.repository.protocol :refer [TheaterRepository]]))
+
+(defn save! [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-id [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-uuid [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-id-by-uuid [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-chain-type [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestTheaterRepository []
+  TheaterRepository
+  (save! [this theater] (save! this theater))
+  (find-by-id [this id] (find-by-id this id))
+  (find-by-uuid [this uuid] (find-by-uuid this uuid))
+  (find-id-by-uuid [this uuid] (find-id-by-uuid this uuid))
+  (find-by-chain-type [this chain-type] (find-by-chain-type this chain-type))) 

--- a/test/clj/kit/spooky_town/domain/theater/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/theater/test/repository.clj
@@ -16,6 +16,9 @@
 (defn find-by-chain-type [_ _]
   (throw (ex-info "Not implemented" {})))
 
+(defn find-id-by-name [_ _]
+  (throw (ex-info "Not implemented" {})))
+
 (defn delete! [_ _]
   (throw (ex-info "Not implemented" {})))
 
@@ -26,4 +29,5 @@
   (find-by-uuid [this uuid] (find-by-uuid this uuid))
   (find-id-by-uuid [this uuid] (find-id-by-uuid this uuid))
   (find-by-chain-type [this chain-type] (find-by-chain-type this chain-type))
+  (find-id-by-name [this name] (find-id-by-name this name))
   (delete! [this theater] (delete! this theater))) 

--- a/test/clj/kit/spooky_town/domain/theater/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/theater/test/repository.clj
@@ -16,10 +16,14 @@
 (defn find-by-chain-type [_ _]
   (throw (ex-info "Not implemented" {})))
 
+(defn delete! [_ _]
+  (throw (ex-info "Not implemented" {})))
+
 (defrecord TestTheaterRepository []
   TheaterRepository
   (save! [this theater] (save! this theater))
   (find-by-id [this id] (find-by-id this id))
   (find-by-uuid [this uuid] (find-by-uuid this uuid))
   (find-id-by-uuid [this uuid] (find-id-by-uuid this uuid))
-  (find-by-chain-type [this chain-type] (find-by-chain-type this chain-type))) 
+  (find-by-chain-type [this chain-type] (find-by-chain-type this chain-type))
+  (delete! [this theater] (delete! this theater))) 

--- a/test/clj/kit/spooky_town/domain/theater/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/theater/use_case_test.clj
@@ -1,0 +1,75 @@
+(ns kit.spooky-town.domain.theater.use-case-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.theater.use-case :as use-case :refer [->TheaterUseCaseImpl]]
+            [kit.spooky-town.domain.theater.test.repository :as theater-repository-fixture :refer [->TestTheaterRepository]]
+            [kit.spooky-town.domain.common.id.test.generator :as id-generator-fixture :refer [->TestIdGenerator]]
+            [kit.spooky-town.domain.common.id.test.uuid-generator :as uuid-generator-fixture :refer [->TestUuidGenerator]]))
+
+(def base-command
+  {:chain-type :cgv})
+
+(deftest theater-use-case-test
+  (let [with-tx (fn [[repo] f] (f repo))
+        theater-repository (->TestTheaterRepository)
+        id-generator (->TestIdGenerator)
+        uuid-generator (->TestUuidGenerator)
+        use-case (->TheaterUseCaseImpl 
+                  theater-repository 
+                  id-generator 
+                  uuid-generator 
+                  with-tx)]
+
+    (testing "극장 생성"
+      (with-redefs [id-generator-fixture/generate-ulid (constantly "01HQ1234567890ABCDEFGHJKLM")
+                    theater-repository-fixture/save! (fn [_ theater] theater)]
+        (let [result (use-case/create-theater! use-case base-command)]
+          (is (some? result))
+          (is (= (:chain-type base-command) (:chain-type result)))
+          (is (= "01HQ1234567890ABCDEFGHJKLM" (:theater-id result)))
+          (is (= #uuid "550e8400-e29b-41d4-a716-446655440000" (:uuid result))))))
+
+    (testing "극장 정보 수정"
+      (let [theater-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+            existing-theater {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                            :uuid theater-uuid
+                            :chain-type :cgv
+                            :created-at (java.util.Date.)
+                            :updated-at (java.util.Date.)}]
+        
+        (testing "존재하는 극장"
+          (with-redefs [theater-repository-fixture/find-by-uuid
+                       (fn [_ uuid] (when (= uuid theater-uuid) existing-theater))
+                       theater-repository-fixture/save! (fn [_ theater] theater)]
+            (let [command {:theater-uuid theater-uuid
+                          :chain-type :megabox}
+                  result (use-case/update-theater! use-case command)]
+              (is (some? result))
+              (is (= :megabox (:chain-type result)))
+              (is (= (:theater-id existing-theater) (:theater-id result))))))
+
+        (testing "존재하지 않는 극장"
+          (with-redefs [theater-repository-fixture/find-by-uuid (constantly nil)]
+            (let [command {:theater-uuid #uuid "550e8400-e29b-41d4-a716-446655440001"
+                          :chain-type :megabox}]
+              (is (nil? (use-case/update-theater! use-case command))))))))
+
+    (testing "극장 삭제"
+      (let [theater-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+            existing-theater {:theater-id "01HQ1234567890ABCDEFGHJKLM"
+                            :uuid theater-uuid
+                            :chain-type :cgv
+                            :created-at (java.util.Date.)
+                            :updated-at (java.util.Date.)}]
+        
+        (testing "존재하는 극장"
+          (with-redefs [theater-repository-fixture/find-by-uuid
+                       (fn [_ uuid] (when (= uuid theater-uuid) existing-theater))
+                       theater-repository-fixture/delete! (fn [_ _] true)]
+            (let [command {:theater-uuid theater-uuid}]
+              (is (true? (use-case/delete-theater! use-case command))))))
+
+        (testing "존재하지 않는 극장"
+          (with-redefs [theater-repository-fixture/find-by-uuid (constantly nil)]
+            (let [command {:theater-uuid #uuid "550e8400-e29b-41d4-a716-446655440001"}]
+              (is (nil? (use-case/delete-theater! use-case command))))))))))
+


### PR DESCRIPTION
이번 PR에서는 극장과 영화 간의 관계를 추가하고, 영화 엔티티 및 관련 API를 업데이트했습니다. 주요 변경사항은 다음과 같습니다:

### 주요 변경사항

1. **데이터베이스 스키마 변경**:
   - `movie_theaters` 및 `theaters` 테이블 추가
   - 극장 관련 쿼리 추가: 극장 생성, 조회, 삭제 및 영화-극장 관계 관리

2. **레포지토리 및 서비스 추가**:
   - `theater-repository` 및 `movie-theater-repository` 추가
   - `movie-query-service`에 `movie-theater-repository` 의존성 추가

3. **영화 엔티티 및 API 업데이트**:
   - `movie-uuid` 및 `release-info` 필드를 포함하도록 영화 엔티티 요약 함수 업데이트
   - `find-movie` 함수에 극장 정보 포함
   - `CreateMovieCommand` 및 `UpdateMovieCommand`에 `theater-infos` 추가

4. **Swagger 문서 업데이트**:
   - 영화 생성, 검색, 업데이트, 상세 정보 조회 API의 Swagger 문서 최신화
   - `release-info`, `genres`, `runtime`, `actor-ids`, `director-ids`, `theater-ids` 필드 추가

5. **테스트 추가 및 수정**:
   - 극장 및 영화-극장 관계에 대한 테스트 추가
   - 영화 엔티티 테스트에 `movie-uuid` 및 `release-info` 필드 포함
   - 영화 쿼리 테스트에 극장 정보 포함

### 기타 변경사항

- `delete-by-movie-id!` 함수 추가: 영화 감독 레포지토리 프로토콜에 추가
- `find-id-by-uuid` 함수 추가: `TestMovieRepository`에 추가

### 관련이슈

closes #28 
