### PR TITLE
영화 삭제 기능 구현

### DIFF
--- a/resources/migrations/20240321000001-create-movies-table.up.sql
+++ b/resources/migrations/20240321000001-create-movies-table.up.sql
@@ -4,6 +4,10 @@ CREATE TABLE IF NOT EXISTS movies (
   title VARCHAR(255) NOT NULL,
   description TEXT,
   release_date DATE,
+  is_deleted BOOLEAN DEFAULT FALSE NOT NULL,
+  deleted_at TIMESTAMP WITH TIME ZONE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 ); 
+
+CREATE INDEX idx_movies_is_deleted ON movies(is_deleted); 

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -305,3 +305,12 @@ WHERE movie_id = :movie_id AND theater_id = :theater_id;
 SELECT theater_id, uuid, chain_type, created_at, updated_at
 FROM theaters
 WHERE theater_name = :theater_name;
+
+-- :name get-user-roles-by-uuid :? :*
+-- :doc UUID로 사용자의 모든 역할을 조회합니다
+SELECT r.role_name as role
+FROM roles r
+JOIN user_roles ur ON r.role_id = ur.role_id
+JOIN users u ON ur.user_id = u.user_id
+WHERE u.uuid = :user_uuid
+  AND u.deleted_at IS NULL;

--- a/resources/sql/queries.sql
+++ b/resources/sql/queries.sql
@@ -122,12 +122,13 @@ FROM movies
 WHERE uuid = :uuid AND deleted_at IS NULL;
 
 -- :name mark-movie-as-deleted! :! :n
--- :doc 영화를 소프트 삭제 처리합니다
+-- :doc 영화를 논리적으로 삭제 처리합니다
 UPDATE movies
-SET deleted_at = CURRENT_TIMESTAMP,
-    updated_at = CURRENT_TIMESTAMP
+SET deleted_at = :deleted_at,
+    updated_at = CURRENT_TIMESTAMP,
+    is_deleted = true
 WHERE movie_id = :movie_id
-RETURNING movie_id, uuid, deleted_at;
+RETURNING movie_id, uuid, deleted_at, is_deleted;
 
 -- 감독 관련 쿼리
 -- :name save-director! :! :n
@@ -314,3 +315,38 @@ JOIN user_roles ur ON r.role_id = ur.role_id
 JOIN users u ON ur.user_id = u.user_id
 WHERE u.uuid = :user_uuid
   AND u.deleted_at IS NULL;
+
+-- :name find-movies-by-criteria :? :*
+-- :doc 조건에 따라 영화를 조회합니다
+SELECT m.*
+FROM movies m
+WHERE 1=1
+  AND (:include_deleted IS NULL OR
+       CASE
+         WHEN :include_deleted::boolean = true THEN true
+         ELSE m.deleted_at IS NULL
+       END)
+  AND (:title IS NULL OR m.title ILIKE ('%' || :title || '%'))
+  AND (:release_date_from IS NULL OR m.release_date >= :release_date_from::date)
+  AND (:release_date_to IS NULL OR m.release_date <= :release_date_to::date)
+ORDER BY
+  CASE WHEN :sort_by = 'title' AND :sort_direction = 'asc' THEN m.title END ASC,
+  CASE WHEN :sort_by = 'title' AND :sort_direction = 'desc' THEN m.title END DESC,
+  CASE WHEN :sort_by = 'release_date' AND :sort_direction = 'asc' THEN m.release_date END ASC,
+  CASE WHEN :sort_by = 'release_date' AND :sort_direction = 'desc' THEN m.release_date END DESC,
+  m.created_at DESC
+LIMIT :limit OFFSET :offset;
+
+-- :name count-movies-by-criteria :? :1
+-- :doc 조건에 맞는 영화의 총 개수를 반환합니다
+SELECT COUNT(*) as count
+FROM movies m
+WHERE 1=1
+  AND (:include_deleted IS NULL OR
+       CASE
+         WHEN :include_deleted::boolean = true THEN true
+         ELSE m.deleted_at IS NULL
+       END)
+  AND (:title IS NULL OR m.title ILIKE ('%' || :title || '%'))
+  AND (:release_date_from IS NULL OR m.release_date >= :release_date_from::date)
+  AND (:release_date_to IS NULL OR m.release_date <= :release_date_to::date);

--- a/resources/system.edn
+++ b/resources/system.edn
@@ -164,6 +164,11 @@
   :api-key #or [#env CLOUDINARY_API_KEY "your-api-key"]
   :api-secret #or [#env CLOUDINARY_API_SECRET "your-api-secret"]}
 
+ :infrastructure/user-authorization
+ {:datasource #ig/ref :db.sql/connection
+  :tx-manager #ig/ref :db/tx-manager
+  :queries #ig/ref :db.sql/queries}
+
  :infrastructure/role-repository
  {:datasource #ig/ref :db.sql/connection
   :tx-manager #ig/ref :db/tx-manager
@@ -193,18 +198,19 @@
   :role-request-repository #ig/ref :infrastructure/role-request-repository
   :event-publisher #ig/ref :infrastructure/event-bus}
 
-:domain/movie-use-case
-{:with-tx #ig/ref :db/tx-manager
- :movie-repository #ig/ref :infrastructure/movie-repository
- :movie-director-repository #ig/ref :infrastructure/movie-director-repository
- :movie-actor-repository #ig/ref :infrastructure/movie-actor-repository
- :movie-theater-repository #ig/ref :infrastructure/movie-theater-repository
- :theater-repository #ig/ref :infrastructure/theater-repository
- :director-repository #ig/ref :infrastructure/director-repository
- :actor-repository #ig/ref :infrastructure/actor-repository
- :image-gateway #ig/ref :infrastructure/cloudinary-storage
- :id-generator #ig/ref :infrastructure/id-generator
- :uuid-generator #ig/ref :infrastructure/uuid-generator}
+ :domain/movie-use-case
+ {:with-tx #ig/ref :db/tx-manager
+  :movie-repository #ig/ref :infrastructure/movie-repository
+  :movie-director-repository #ig/ref :infrastructure/movie-director-repository
+  :movie-actor-repository #ig/ref :infrastructure/movie-actor-repository
+  :movie-theater-repository #ig/ref :infrastructure/movie-theater-repository
+  :theater-repository #ig/ref :infrastructure/theater-repository
+  :director-repository #ig/ref :infrastructure/director-repository
+  :actor-repository #ig/ref :infrastructure/actor-repository
+  :image-gateway #ig/ref :infrastructure/cloudinary-storage
+  :id-generator #ig/ref :infrastructure/id-generator
+  :uuid-generator #ig/ref :infrastructure/uuid-generator
+  :user-authorization #ig/ref :infrastructure/user-authorization}
 
  :domain/movie-query-service
  {:movie-repository #ig/ref :infrastructure/movie-repository

--- a/src/clj/kit/spooky_town/core.clj
+++ b/src/clj/kit/spooky_town/core.clj
@@ -21,6 +21,7 @@
    [kit.spooky-town.infrastructure.auth.jwt-email-token-gateway]
    [kit.spooky-town.infrastructure.auth.bcrypt-gateway]
    [kit.spooky-town.infrastructure.auth.email-verification-gateway]
+   [kit.spooky-town.infrastructure.auth.authorization]
    [kit.spooky-town.infrastructure.id.ulid]
    [kit.spooky-town.infrastructure.id.uuid-generator]
    [kit.spooky-town.infrastructure.image.cloudinary]

--- a/src/clj/kit/spooky_town/domain/auth/authorization/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/auth/authorization/protocol.clj
@@ -1,0 +1,6 @@
+(ns kit.spooky-town.domain.auth.authorization.protocol)
+
+(defprotocol UserAuthorization
+  (has-permission? [this user-uuid permission]
+    "사용자가 특정 권한을 가지고 있는지 확인합니다.
+     permission: #{:admin :content-manager}")) 

--- a/src/clj/kit/spooky_town/domain/movie/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/movie/repository/protocol.clj
@@ -13,7 +13,6 @@
   (find-id-by-uuid [this uuid]
     "UUID로 영화 ID를 조회합니다.")
 
-  ;; 새로 추가되는 메서드들
   (find-by-criteria [this criteria]
     "주어진 조건으로 영화 목록을 검색합니다.
      criteria: {:page pos-int?
@@ -23,7 +22,11 @@
                :director-name string?
                :actor-name string?
                :genres set?
-               :release-status keyword?}")
+               :release-status keyword?
+               :include-deleted? boolean?}")
 
   (count-by-criteria [this criteria]
-    "검색 조건에 맞는 전체 영화 수를 반환합니다."))
+    "검색 조건에 맞는 전체 영화 수를 반환합니다.")
+
+ (mark-as-deleted! [this movie-id timestamp]
+                   "영화를 논리적으로 삭제 처리합니다."))

--- a/src/clj/kit/spooky_town/infrastructure/auth/authorization.clj
+++ b/src/clj/kit/spooky_town/infrastructure/auth/authorization.clj
@@ -1,0 +1,24 @@
+(ns kit.spooky-town.infrastructure.auth.authorization
+  (:require [kit.spooky-town.domain.auth.authorization.protocol :refer [UserAuthorization]]
+            [kit.spooky-town.infrastructure.persistence.transaction :refer [UpdateQueryFn]]
+            [integrant.core :as ig]
+            [next.jdbc.result-set :as rs]))
+
+(defrecord UserAuthorizationImpl [datasource tx-manager queries]
+  UpdateQueryFn
+  (update-query-fn [this tx-fn]
+    (assoc this :query-fn tx-fn))
+
+  UserAuthorization
+  (has-permission? [this user-uuid permission]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)
+              roles (query-fn (:get-user-roles queries)
+                            {:user_uuid user-uuid}
+                            {:builder-fn rs/as-unqualified-maps})]
+          (contains? (set (map :role roles)) permission))))))
+
+(defmethod ig/init-key :infrastructure/user-authorization
+  [_ {:keys [datasource tx-manager queries]}]
+  (->UserAuthorizationImpl datasource tx-manager queries)) 

--- a/src/clj/kit/spooky_town/infrastructure/persistence/movie.clj
+++ b/src/clj/kit/spooky_town/infrastructure/persistence/movie.clj
@@ -32,7 +32,32 @@
         (let [query-fn (:query-fn repo)]
           (query-fn (:get-movie-by-uuid queries)
                    {:uuid uuid}
-                   {:builder-fn rs/as-unqualified-maps}))))))
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (mark-as-deleted! [this movie-id timestamp]
+    (.with-tx tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:mark-movie-as-deleted! queries)
+                   {:movie_id movie-id
+                    :deleted_at timestamp}
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (find-by-criteria [this {:keys [include-deleted?] :as criteria}]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (query-fn (:find-movies-by-criteria queries)
+                   (assoc criteria :include_deleted include-deleted?)
+                   {:builder-fn rs/as-unqualified-maps})))))
+
+  (count-by-criteria [this criteria]
+    (.with-read-only tx-manager [this]
+      (fn [repo]
+        (let [query-fn (:query-fn repo)]
+          (:count (query-fn (:count-movies-by-criteria queries)
+                           criteria
+                           {:builder-fn rs/as-unqualified-maps})))))))
 
 (defmethod ig/init-key :infrastructure/movie-repository
   [_ {:keys [datasource tx-manager queries]}]

--- a/src/clj/kit/spooky_town/web/controllers/movie.clj
+++ b/src/clj/kit/spooky_town/web/controllers/movie.clj
@@ -32,4 +32,15 @@
     (if (f/failed? result)
       (response/bad-request {:error (f/message result)})
       (response/ok {:movie-id result}))))
+
+(defn delete-movie [{:keys [path-params identity movie-use-case]}]
+  (let [command {:movie-uuid (parse-uuid (:movie-uuid path-params))
+                 :user-id (:uuid identity)}
+        result (movie-use-case/delete-movie! movie-use-case command)]
+    (cond
+      (f/failed? result) (case (::f/type result)
+                          :unauthorized (response/forbidden {:error (f/message result)})
+                          :not-found (response/not-found)
+                          (response/bad-request {:error (f/message result)}))
+      :else (response/ok {:success true}))))
  

--- a/src/clj/kit/spooky_town/web/routes/movie.clj
+++ b/src/clj/kit/spooky_town/web/routes/movie.clj
@@ -96,7 +96,15 @@
                   :responses {200 {:body [:map [:movie-uuid string?]]}
                              400 {:body [:map [:error string?]]}
                              404 {:body empty?}}
-                  :handler movie/update-movie}})]
+                  :handler movie/update-movie}
+            
+            :delete {:summary "Delete movie"
+                    :parameters {:path [:map [:movie-uuid string?]]}
+                    :responses {200 {:body [:map [:success boolean?]]}
+                              400 {:body [:map [:error string?]]}
+                              403 {:body [:map [:error string?]]}
+                              404 {:body empty?}}
+                    :handler movie/delete-movie}})]
    
    ["/:movie-uuid/summary"
     {:get {:summary "Get movie summary"

--- a/test/clj/kit/spooky_town/domain/auth/test/authorization.clj
+++ b/test/clj/kit/spooky_town/domain/auth/test/authorization.clj
@@ -1,0 +1,11 @@
+(ns kit.spooky-town.domain.auth.test.authorization
+  (:require [kit.spooky-town.domain.auth.authorization.protocol :refer [UserAuthorization]]))
+
+(defn has-permission? [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestUserAuthorization []
+  UserAuthorization
+  (has-permission? [this user-uuid permission]
+    (has-permission? this user-uuid permission)))
+

--- a/test/clj/kit/spooky_town/domain/movie/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/movie/test/repository.clj
@@ -19,6 +19,9 @@
 (defn find-id-by-uuid [_ _]
   (throw (ex-info "Not implemented" {})))
 
+(defn mark-as-deleted! [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
 (defrecord TestMovieRepository []
   MovieRepository
   (save! [this movie] (save! this movie))
@@ -26,4 +29,32 @@
   (find-by-uuid [this uuid] (find-by-uuid this uuid))
   (find-by-criteria [this criteria] (find-by-criteria this criteria))
   (count-by-criteria [this criteria] (count-by-criteria this criteria))
-  (find-id-by-uuid [this uuid] (find-id-by-uuid this uuid))) 
+  (find-id-by-uuid [this uuid] (find-id-by-uuid this uuid))
+ (mark-as-deleted! [this movie-id timestamp] (mark-as-deleted! this movie-id timestamp)))
+
+;; 테스트 헬퍼 함수들
+(defn create-test-repository
+  ([]
+   (create-test-repository {}))
+  ([{:keys [save!-fn
+            find-by-id-fn
+            find-by-uuid-fn
+            find-by-criteria-fn
+            count-by-criteria-fn
+            find-id-by-uuid-fn
+            mark-as-deleted!-fn]
+     :or {save!-fn (fn [_ _] nil)
+          find-by-id-fn (fn [_ _] nil)
+          find-by-uuid-fn (fn [_ _] nil)
+          find-by-criteria-fn (fn [_ _] [])
+          count-by-criteria-fn (fn [_ _] 0)
+          find-id-by-uuid-fn (fn [_ _] nil)
+          mark-as-deleted!-fn (fn [_ _ _] nil)}}]
+   (reify MovieRepository
+     (save! [_ movie] (save!-fn movie))
+     (find-by-id [_ id] (find-by-id-fn id))
+     (find-by-uuid [_ uuid] (find-by-uuid-fn uuid))
+     (find-by-criteria [_ criteria] (find-by-criteria-fn criteria))
+     (count-by-criteria [_ criteria] (count-by-criteria-fn criteria))
+     (find-id-by-uuid [_ uuid] (find-id-by-uuid-fn uuid))
+     (mark-as-deleted! [_ movie-id timestamp] (mark-as-deleted!-fn movie-id timestamp))))) 


### PR DESCRIPTION
# 영화 삭제 기능 구현

## 변경 사항 개요
영화의 논리적 삭제(soft delete) 기능을 구현하고, 관리자 및 콘텐츠 관리자만 삭제할 수 있도록 권한 관리 기능을 추가했습니다.

### 주요 기능
1. 영화 논리적 삭제
   - `is_deleted` 및 `deleted_at` 필드 추가
   - 삭제된 영화는 수정 불가
   - 삭제 상태 조회 기능

2. 권한 관리
   - UserAuthorization 프로토콜 추가
   - admin/content-manager 권한 체크
   - 권한별 영화 삭제 접근 제어

3. API 엔드포인트
   - DELETE /api/movies/:movie-uuid
   - 권한 없음(403), 영화 없음(404) 등 적절한 에러 처리

## 테스트
- 엔티티 테스트: 삭제 상태 관리, 수정 제한
- UseCase 테스트: 권한별 삭제 시나리오
- 통합 테스트: API 엔드포인트

## 기술적 구현
```sql
-- 영화 테이블 변경
ALTER TABLE movies ADD COLUMN is_deleted BOOLEAN DEFAULT FALSE NOT NULL;
ALTER TABLE movies ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
CREATE INDEX idx_movies_is_deleted ON movies(is_deleted);
```

## 리뷰 포인트
1. 논리적 삭제 구현 방식
2. 권한 관리 아키텍처
3. 에러 처리 전략
4. 테스트 커버리지

## 관련 이슈
Closes #30 
