### PR TITLE
OTT 플랫폼 및 영화-OTT 연결 도메인 모델 구현

### DIFF
--- a/resources/migrations/[timestamp]_create_movie_providers.down.sql
+++ b/resources/migrations/[timestamp]_create_movie_providers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS movie_providers; 

--- a/resources/migrations/[timestamp]_create_movie_providers.up.sql
+++ b/resources/migrations/[timestamp]_create_movie_providers.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE movie_providers (
+  movie_id VARCHAR(26) REFERENCES movies(movie_id),
+  provider_id VARCHAR(26) REFERENCES watch_providers(provider_id),
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (movie_id, provider_id)
+); 

--- a/resources/migrations/[timestamp]_create_watch_providers.down.sql
+++ b/resources/migrations/[timestamp]_create_watch_providers.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS watch_providers; 

--- a/resources/migrations/[timestamp]_create_watch_providers.up.sql
+++ b/resources/migrations/[timestamp]_create_watch_providers.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE watch_providers (
+  provider_id VARCHAR(26) PRIMARY KEY,
+  provider_name VARCHAR(50) NOT NULL UNIQUE,
+  logo_url TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO watch_providers (provider_id, provider_name) VALUES
+  ('NETFLIX', 'Netflix'),
+  ('DISNEY_PLUS', 'Disney Plus'),
+  ('WAVVE', 'Wavve'),
+  ('GOOGLE_PLAY', 'Google Play'),
+  ('TVING', 'TVING'); 

--- a/src/clj/kit/spooky_town/domain/movie_provider/entity.clj
+++ b/src/clj/kit/spooky_town/domain/movie_provider/entity.clj
@@ -1,0 +1,23 @@
+(ns kit.spooky-town.domain.movie-provider.entity
+  (:require [kit.spooky-town.domain.movie-provider.value :as value]
+            [clojure.spec.alpha :as s]))
+
+;; 엔티티 스펙
+(s/def ::movie-provider
+  (s/keys :req-un [::value/movie-provider-id
+                   ::value/movie-id
+                   ::value/provider-id
+                   ::value/created-at
+                   ::value/uuid]))
+
+(defrecord MovieProvider [movie-provider-id movie-id provider-id created-at uuid])
+
+(defn create-movie-provider [{:keys [movie-provider-id movie-id provider-id created-at uuid]}]
+  (let [movie-provider (map->MovieProvider
+                        {:movie-provider-id movie-provider-id
+                         :movie-id movie-id
+                         :provider-id provider-id
+                         :created-at created-at
+                         :uuid uuid})]
+    (when (s/valid? ::movie-provider movie-provider)
+      movie-provider))) 

--- a/src/clj/kit/spooky_town/domain/movie_provider/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/movie_provider/repository/protocol.clj
@@ -1,0 +1,20 @@
+(ns kit.spooky-town.domain.movie-provider.repository.protocol)
+
+(defprotocol MovieProviderRepository
+  (save! [this movie-provider]
+    "영화-OTT 플랫폼 연결 정보를 저장합니다.")
+  
+  (find-by-id [this movie-provider-id]
+    "ID로 영화-OTT 플랫폼 연결 정보를 조회합니다.")
+  
+  (find-by-uuid [this uuid]
+    "UUID로 영화-OTT 플랫폼 연결 정보를 조회합니다.")
+  
+  (find-by-movie [this movie-id]
+    "영화 ID로 연결된 OTT 플랫폼들을 조회합니다.")
+  
+  (find-by-provider [this provider-id]
+    "OTT 플랫폼 ID로 연결된 영화들을 조회합니다.")
+  
+  (delete! [this movie-provider-id]
+    "영화-OTT 플랫폼 연결을 삭제합니다.")) 

--- a/src/clj/kit/spooky_town/domain/movie_provider/value.clj
+++ b/src/clj/kit/spooky_town/domain/movie_provider/value.clj
@@ -1,0 +1,34 @@
+(ns kit.spooky-town.domain.movie-provider.value
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+;; movie-provider-id
+(s/def ::movie-provider-id (s/and string? #(not (str/blank? %))))
+
+(defn create-movie-provider-id [value]
+  (when (s/valid? ::movie-provider-id value)
+    value))
+
+;; movie-id
+(s/def ::movie-id (s/and string? #(not (str/blank? %))))
+
+(defn create-movie-id [value]
+  (when (s/valid? ::movie-id value)
+    value))
+
+;; provider-id
+(s/def ::provider-id (s/and string? #(not (str/blank? %))))
+
+(defn create-provider-id [value]
+  (when (s/valid? ::provider-id value)
+    value))
+
+;; created-at
+(s/def ::created-at inst?)
+
+(defn create-timestamp [value]
+  (when (s/valid? ::created-at value)
+    value))
+
+;; uuid
+(s/def ::uuid uuid?) 

--- a/src/clj/kit/spooky_town/domain/watch_provider/entity.clj
+++ b/src/clj/kit/spooky_town/domain/watch_provider/entity.clj
@@ -6,19 +6,18 @@
 (s/def ::watch-provider
   (s/keys :req-un [::value/provider-id
                    ::value/provider-name
-                   ::value/created-at]
+                   ::value/created-at
+                   ::value/uuid]
           :opt-un [::value/logo-url]))
 
-(defrecord WatchProvider [provider-id provider-name logo-url created-at]
-  Object
-  (toString [this]
-    (str "WatchProvider[" provider-id "," provider-name "]")))
+(defrecord WatchProvider [provider-id provider-name logo-url created-at uuid])
 
-(defn create-watch-provider [{:keys [provider-id provider-name logo-url created-at]}]
+(defn create-watch-provider [{:keys [provider-id provider-name logo-url created-at uuid]}]
   (let [watch-provider (map->WatchProvider
                         {:provider-id provider-id
                          :provider-name provider-name
                          :logo-url logo-url
-                         :created-at created-at})]
+                         :created-at created-at
+                         :uuid uuid})]
     (when (s/valid? ::watch-provider watch-provider)
       watch-provider)))

--- a/src/clj/kit/spooky_town/domain/watch_provider/entity.clj
+++ b/src/clj/kit/spooky_town/domain/watch_provider/entity.clj
@@ -1,0 +1,24 @@
+(ns kit.spooky-town.domain.watch-provider.entity
+  (:require [kit.spooky-town.domain.watch-provider.value :as value]
+            [clojure.spec.alpha :as s]))
+
+;; 엔티티 스펙
+(s/def ::watch-provider
+  (s/keys :req-un [::value/provider-id
+                   ::value/provider-name
+                   ::value/created-at]
+          :opt-un [::value/logo-url]))
+
+(defrecord WatchProvider [provider-id provider-name logo-url created-at]
+  Object
+  (toString [this]
+    (str "WatchProvider[" provider-id "," provider-name "]")))
+
+(defn create-watch-provider [{:keys [provider-id provider-name logo-url created-at]}]
+  (let [watch-provider (map->WatchProvider
+                        {:provider-id provider-id
+                         :provider-name provider-name
+                         :logo-url logo-url
+                         :created-at created-at})]
+    (when (s/valid? ::watch-provider watch-provider)
+      watch-provider)))

--- a/src/clj/kit/spooky_town/domain/watch_provider/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/watch_provider/repository/protocol.clj
@@ -1,0 +1,20 @@
+(ns kit.spooky-town.domain.watch-provider.repository.protocol)
+
+(defprotocol WatchProviderRepository
+  (save! [this watch-provider]
+    "OTT 플랫폼 정보를 저장합니다.")
+
+  (find-by-id [this provider-id]
+    "ID로 OTT 플랫폼을 조회합니다.")
+
+  (find-by-uuid [this uuid]
+    "UUID로 OTT 플랫폼을 조회합니다.")
+
+  (find-by-name [this provider-name]
+    "이름으로 OTT 플랫폼을 조회합니다.")
+
+  (find-all [this]
+    "모든 OTT 플랫폼을 조회합니다.")
+
+  (delete! [this provider-id]
+    "OTT 플랫폼을 삭제합니다.")) 

--- a/src/clj/kit/spooky_town/domain/watch_provider/value.clj
+++ b/src/clj/kit/spooky_town/domain/watch_provider/value.clj
@@ -38,3 +38,6 @@
 (defn create-timestamp [value]
   (when (s/valid? ::created-at value)
     value))
+
+;; uuid
+(s/def ::uuid uuid?)

--- a/src/clj/kit/spooky_town/domain/watch_provider/value.clj
+++ b/src/clj/kit/spooky_town/domain/watch_provider/value.clj
@@ -1,0 +1,40 @@
+(ns kit.spooky-town.domain.watch-provider.value
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as str]))
+
+;; provider-id
+(s/def ::provider-id (s/and string? #(not (str/blank? %))))
+
+(defrecord WatchProviderId [value])
+
+(defn create-provider-id [value]
+  (when (s/valid? ::provider-id value)
+    (->WatchProviderId value)))
+
+;; provider-name
+(def max-provider-name-length 50)
+(s/def ::provider-name (s/and string?
+                              #(not (str/blank? %))
+                              #(<= (count %) max-provider-name-length)))
+
+(defn create-provider-name [value]
+  (when (s/valid? ::provider-name value)
+    value))
+
+;; logo-url
+(def url-pattern #"^https?://.*")
+(s/def ::logo-url (s/nilable (s/and string?
+                                    #(re-matches url-pattern %))))
+
+(defn create-logo-url [value]
+  (when (or (nil? value)
+            (s/valid? ::logo-url value))
+    value))
+
+;; created-at
+(s/def ::created-at inst?)
+
+
+(defn create-timestamp [value]
+  (when (s/valid? ::created-at value)
+    value))

--- a/test/clj/kit/spooky_town/domain/movie_provider/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie_provider/entity_test.clj
@@ -1,0 +1,38 @@
+(ns kit.spooky-town.domain.movie-provider.entity-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.movie-provider.entity :as entity]))
+
+(deftest create-movie-provider-test
+  (testing "유효한 데이터로 MovieProvider 생성"
+    (let [now (java.util.Date.)
+          test-uuid (random-uuid)
+          movie-provider (entity/create-movie-provider
+                          {:movie-provider-id "MP123"
+                           :movie-id "MV456"
+                           :provider-id "provider!@#!"
+                           :created-at now
+                           :uuid test-uuid})]
+      (is (some? movie-provider))
+      (is (= "MP123" (:movie-provider-id movie-provider)))
+      (is (= "MV456" (:movie-id movie-provider)))
+      (is (= "provider!@#!" (:provider-id movie-provider)))
+      (is (= now (:created-at movie-provider)))
+      (is (= test-uuid (:uuid movie-provider)))))
+
+  (testing "필수 필드가 없으면 MovieProvider 생성 실패"
+    (is (nil? (entity/create-movie-provider
+                {:movie-id "MV456"
+                 :provider-id "provider!@#!"})))
+    
+    (is (nil? (entity/create-movie-provider
+                {:movie-provider-id "MP123"
+                 :provider-id "provider!@#!"})))
+    
+    (is (nil? (entity/create-movie-provider
+                {:movie-provider-id "MP123"
+                 :movie-id "MV456"})))
+    
+    (is (nil? (entity/create-movie-provider
+                {:movie-provider-id "MP123"
+                 :movie-id "MV456"
+                 :provider-id "provider!@#!"}))))) 

--- a/test/clj/kit/spooky_town/domain/watch_provider/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/watch_provider/entity_test.clj
@@ -6,25 +6,30 @@
 (deftest create-watch-provider-test
   (testing "유효한 데이터로 WatchProvider 생성"
     (let [now (java.util.Date.)
+          test-uuid (java.util.UUID/randomUUID)
           watch-provider (entity/create-watch-provider
                           {:provider-id "NETFLIX"
                            :provider-name "Netflix"
                            :logo-url "https://example.com/netflix.png"
-                           :created-at now})]
+                           :created-at now
+                           :uuid test-uuid})]
       (is (some? watch-provider))
       (is (= "NETFLIX" (:provider-id watch-provider)))
       (is (= "Netflix" (:provider-name watch-provider)))
       (is (= "https://example.com/netflix.png" (:logo-url watch-provider)))
-      (is (= now (:created-at watch-provider)))))
+      (is (= now (:created-at watch-provider)))
+      (is (uuid? (:uuid watch-provider)))))
 
   (testing "logo-url이 없어도 WatchProvider 생성 가능"
     (let [now (java.util.Date.)
+          test-uuid (java.util.UUID/randomUUID)
           watch-provider (entity/create-watch-provider
                           {:provider-id "WAVVE"
                            :provider-name "Wavve"
-                           :created-at now})]
+                           :created-at now
+                           :uuid test-uuid})]
       (is (some? watch-provider))
-      (is (nil? (:logo-url watch-provider)))))
+      (is (nil? (:logo-url watch-provider))))))
 
   (testing "필수 필드가 없으면 WatchProvider 생성 실패"
     (is (nil? (entity/create-watch-provider
@@ -34,11 +39,3 @@
     (is (nil? (entity/create-watch-provider
                 {:provider-id "NETFLIX"
                  :provider-name "Netflix"}))))
-
-  (testing "toString 메서드 테스트"
-    (let [watch-provider (entity/create-watch-provider
-                          {:provider-id "NETFLIX"
-                           :provider-name "Netflix"
-                           :created-at (java.util.Date.)})]
-      (is (= "WatchProvider[NETFLIX,Netflix]"
-             (str watch-provider)))))) 

--- a/test/clj/kit/spooky_town/domain/watch_provider/entity_test.clj
+++ b/test/clj/kit/spooky_town/domain/watch_provider/entity_test.clj
@@ -1,0 +1,44 @@
+(ns kit.spooky-town.domain.watch-provider.entity-test
+  (:require [clojure.test :refer :all]
+            [kit.spooky-town.domain.watch-provider.entity :as entity]
+            [kit.spooky-town.domain.watch-provider.value :as value]))
+
+(deftest create-watch-provider-test
+  (testing "유효한 데이터로 WatchProvider 생성"
+    (let [now (java.util.Date.)
+          watch-provider (entity/create-watch-provider
+                          {:provider-id "NETFLIX"
+                           :provider-name "Netflix"
+                           :logo-url "https://example.com/netflix.png"
+                           :created-at now})]
+      (is (some? watch-provider))
+      (is (= "NETFLIX" (:provider-id watch-provider)))
+      (is (= "Netflix" (:provider-name watch-provider)))
+      (is (= "https://example.com/netflix.png" (:logo-url watch-provider)))
+      (is (= now (:created-at watch-provider)))))
+
+  (testing "logo-url이 없어도 WatchProvider 생성 가능"
+    (let [now (java.util.Date.)
+          watch-provider (entity/create-watch-provider
+                          {:provider-id "WAVVE"
+                           :provider-name "Wavve"
+                           :created-at now})]
+      (is (some? watch-provider))
+      (is (nil? (:logo-url watch-provider)))))
+
+  (testing "필수 필드가 없으면 WatchProvider 생성 실패"
+    (is (nil? (entity/create-watch-provider
+                {:provider-id "NETFLIX"})))
+    (is (nil? (entity/create-watch-provider
+                {:provider-name "Netflix"})))
+    (is (nil? (entity/create-watch-provider
+                {:provider-id "NETFLIX"
+                 :provider-name "Netflix"}))))
+
+  (testing "toString 메서드 테스트"
+    (let [watch-provider (entity/create-watch-provider
+                          {:provider-id "NETFLIX"
+                           :provider-name "Netflix"
+                           :created-at (java.util.Date.)})]
+      (is (= "WatchProvider[NETFLIX,Netflix]"
+             (str watch-provider)))))) 


### PR DESCRIPTION
# OTT 플랫폼 및 영화-OTT 연결 도메인 모델 구현

## 개요
OTT 플랫폼 정보와 영화-OTT 플랫폼 간의 연결 관계를 관리하기 위한 도메인 모델을 구현했습니다.

## 변경 사항
### 1. 데이터베이스 스키마
- `watch_providers` 테이블 생성
  - provider_id (PK)
  - provider_name (UNIQUE)
  - logo_url
  - created_at
- `movie_providers` 테이블 생성
  - movie_id (FK)
  - provider_id (FK)
  - created_at
  - 복합 PK (movie_id, provider_id)

### 2. WatchProvider 도메인
- 엔티티 및 값 객체 구현
- 유효성 검증을 위한 스펙 정의
- 저장소 프로토콜 정의

### 3. MovieProvider 도메인
- 엔티티 및 값 객체 구현
- 유효성 검증을 위한 스펙 정의
- 저장소 프로토콜 정의

## 테스트
- WatchProvider 엔티티 생성 테스트
- MovieProvider 엔티티 생성 테스트
- 필수 필드 검증 테스트

## 관련 이슈
Closes #32 