### PR TITLE
 OTT 플랫폼 연동 기능 추가

### DIFF
--- a/resources/system.edn
+++ b/resources/system.edn
@@ -151,6 +151,11 @@
   :tx-manager #ig/ref :db/tx-manager
   :queries #ig/ref :db.sql/queries}
 
+ :infrastructure/movie-provider-repository
+ {:datasource #ig/ref :db.sql/connection
+  :tx-manager #ig/ref :db/tx-manager
+  :queries #ig/ref :db.sql/queries}
+
  :infrastructure/email-verification-gateway
  {:secret #or [#env EMAIL_VERIFICATION_SECRET "VERIFICATION_SECRET_HERE"]}
 
@@ -218,7 +223,14 @@
   :movie-director-repository #ig/ref :infrastructure/movie-director-repository
   :movie-theater-repository #ig/ref :infrastructure/movie-theater-repository
   :tx-manager #ig/ref :db/tx-manager}
-
+ 
+  :domain/movie-provider-use-case
+ {:movie-provider-repository #ig/ref :infrastructure/movie-provider-repository
+  :movie-repository #ig/ref :infrastructure/movie-repository
+  :user-authorization #ig/ref :infrastructure/user-authorization
+  :id-generator #ig/ref :infrastructure/ulid-generator
+  :uuid-generator #ig/ref :infrastructure/uuid-generator
+  :with-tx #ig/ref :db/tx-manager}
 
  :reitit.routes/api
  {:base-path ""

--- a/resources/system.edn
+++ b/resources/system.edn
@@ -222,7 +222,8 @@
   :movie-actor-repository #ig/ref :infrastructure/movie-actor-repository
   :movie-director-repository #ig/ref :infrastructure/movie-director-repository
   :movie-theater-repository #ig/ref :infrastructure/movie-theater-repository
-  :tx-manager #ig/ref :db/tx-manager}
+  :movie-provider-repository #ig/ref :infrastructure/movie-provider-repository
+  :with-read-only #ig/ref :db/tx-manager}
  
   :domain/movie-provider-use-case
  {:movie-provider-repository #ig/ref :infrastructure/movie-provider-repository

--- a/resources/system.edn
+++ b/resources/system.edn
@@ -238,5 +238,7 @@
   :tx-manager #ig/ref :db/tx-manager
   :role-request-use-case #ig/ref :domain/role-request-use-case
   :user-use-case #ig/ref :domain/user-use-case
-  :movie-use-case #ig/ref :domain/movie-use-case}}
+  :movie-use-case #ig/ref :domain/movie-use-case
+  :movie-query-service #ig/ref :domain/movie-query-service
+  :movie-provider-use-case #ig/ref :domain/movie-provider-use-case}}
 

--- a/src/clj/kit/spooky_town/core.clj
+++ b/src/clj/kit/spooky_town/core.clj
@@ -43,6 +43,7 @@
    [kit.spooky-town.domain.role-request.use-case]
    [kit.spooky-town.domain.user.use-case]
    [kit.spooky-town.domain.movie.use-case]
+   [kit.spooky-town.domain.movie-provider.use-case]
    ;; Query Services
    [kit.spooky-town.domain.movie.query.service])
 

--- a/src/clj/kit/spooky_town/domain/movie_provider/repository/protocol.clj
+++ b/src/clj/kit/spooky_town/domain/movie_provider/repository/protocol.clj
@@ -16,5 +16,5 @@
   (find-by-provider [this provider-id]
     "OTT 플랫폼 ID로 연결된 영화들을 조회합니다.")
   
-  (delete! [this movie-provider-id]
+  (delete! [this movie-id provider-id]
     "영화-OTT 플랫폼 연결을 삭제합니다.")) 

--- a/src/clj/kit/spooky_town/domain/movie_provider/use_case.clj
+++ b/src/clj/kit/spooky_town/domain/movie_provider/use_case.clj
@@ -1,0 +1,83 @@
+(ns kit.spooky-town.domain.movie-provider.use-case
+  (:require [integrant.core :as ig]
+            [failjure.core :as f]
+            [kit.spooky-town.domain.movie-provider.entity :as entity]
+            [kit.spooky-town.domain.movie-provider.repository.protocol :as movie-provider-repo]
+            [kit.spooky-town.domain.movie.repository.protocol :as movie-repo]
+            [kit.spooky-town.domain.common.id.protocol :as id-generator]
+            [kit.spooky-town.domain.auth.authorization.protocol :refer [has-permission?]]))
+
+(defprotocol MovieProviderUseCase
+  (assign-provider! [this command]
+    "영화에 OTT 플랫폼을 연결합니다.
+     command: {:movie-uuid string?
+               :provider-id string?
+               :user-uuid string?}")
+  
+  (remove-provider! [this command]
+    "영화에서 OTT 플랫폼 연결을 제거합니다.
+     command: {:movie-uuid string?
+               :provider-id string?
+               :user-uuid string?}")
+  
+  (get-providers [this command]
+    "영화에 연결된 모든 OTT 플랫폼을 조회합니다.
+     command: {:movie-uuid string?}")
+  
+  (get-movies-by-provider [this command]
+    "OTT 플랫폼에 연결된 모든 영화를 조회합니다.
+     command: {:provider-id string?}"))
+
+(defrecord MovieProviderUseCaseImpl [movie-provider-repository 
+                                   movie-repository
+                                   user-authorization
+                                   id-generator
+                                   uuid-generator
+                                   with-tx]
+  MovieProviderUseCase
+  (assign-provider! [_ {:keys [movie-uuid provider-id user-uuid]}]
+    (if (has-permission? user-authorization user-uuid :content-manager)
+      (with-tx [movie-provider-repository]
+        (fn [repo]
+          (if-let [movie-id (movie-repo/find-id-by-uuid movie-repository movie-uuid)]
+            (if-let [movie-provider (entity/create-movie-provider
+                                     
+                                    {:movie-provider-id (id-generator/generate-ulid id-generator)
+                                     :uuid (id-generator/generate-uuid uuid-generator)
+                                     :movie-id movie-id
+                                     :provider-id provider-id
+                                     :created-at (java.util.Date.)})]
+              (movie-provider-repo/save! repo movie-provider)
+              (f/fail "유효하지 않은 영화-OTT 플랫폼 연결입니다."))
+            (f/fail "영화를 찾을 수 없습니다."))))
+      (f/fail "OTT 플랫폼을 연결할 권한이 없습니다.")))
+
+  (remove-provider! [_ {:keys [movie-uuid provider-id user-uuid]}]
+    (if (has-permission? user-authorization user-uuid :content-manager)
+      (with-tx [movie-provider-repository]
+        (fn [repo]
+          (if-let [movie-id (movie-repo/find-id-by-uuid movie-repository movie-uuid)]
+            (movie-provider-repo/delete! repo movie-id provider-id)
+            (f/fail "영화를 찾을 수 없습니다."))))
+      (f/fail "OTT 플랫폼 연결을 제거할 권한이 없습니다.")))
+
+  (get-providers [_ {:keys [movie-uuid]}]
+    (when-let [movie-id (movie-repo/find-id-by-uuid movie-repository movie-uuid)]
+      (movie-provider-repo/find-by-movie movie-provider-repository movie-id)))
+
+  (get-movies-by-provider [_ {:keys [provider-id]}]
+    (movie-provider-repo/find-by-provider movie-provider-repository provider-id)))
+
+(defmethod ig/init-key :domain/movie-provider-use-case
+  [_ {:keys [movie-provider-repository 
+             movie-repository 
+             user-authorization 
+             id-generator
+             uuid-generator
+             with-tx]}]
+  (->MovieProviderUseCaseImpl movie-provider-repository 
+                             movie-repository
+                             user-authorization 
+                             id-generator
+                             uuid-generator
+                             with-tx)) 

--- a/src/clj/kit/spooky_town/web/controllers/movie_provider.clj
+++ b/src/clj/kit/spooky_town/web/controllers/movie_provider.clj
@@ -1,0 +1,51 @@
+(ns kit.spooky-town.web.controllers.movie-provider
+  (:require [kit.spooky-town.domain.movie-provider.use-case :as movie-provider]
+            [failjure.core :as f]))
+
+(defn assign-provider
+  [{:keys [parameters movie-provider-use-case]}]
+  (let [{:keys [movie-uuid provider-id]} (:body parameters)
+        user-uuid (-> parameters :auth :user-uuid)
+        result (movie-provider/assign-provider! 
+                movie-provider-use-case 
+                {:movie-uuid movie-uuid
+                 :provider-id provider-id
+                 :user-uuid user-uuid})]
+    (if (f/failed? result)
+      {:status 400
+       :body {:error (f/message result)}}
+      {:status 201
+       :body {:success true}})))
+
+(defn remove-provider
+  [{:keys [parameters movie-provider-use-case]}]
+  (let [{:keys [movie-uuid provider-id]} (:body parameters)
+        user-uuid (-> parameters :auth :user-uuid)
+        result (movie-provider/remove-provider! 
+                movie-provider-use-case 
+                {:movie-uuid movie-uuid
+                 :provider-id provider-id
+                 :user-uuid user-uuid})]
+    (if (f/failed? result)
+      {:status 400
+       :body {:error (f/message result)}}
+      {:status 200
+       :body {:success true}})))
+
+(defn get-providers
+  [{:keys [parameters movie-provider-use-case]}]
+  (let [{:keys [movie-uuid]} (:path parameters)
+        providers (movie-provider/get-providers 
+                   movie-provider-use-case 
+                   {:movie-uuid movie-uuid})]
+    {:status 200
+     :body {:providers providers}}))
+
+(defn get-movies-by-provider
+  [{:keys [parameters movie-provider-use-case]}]
+  (let [{:keys [provider-id]} (:path parameters)
+        movies (movie-provider/get-movies-by-provider 
+                movie-provider-use-case 
+                {:provider-id provider-id})]
+    {:status 200
+     :body {:movies movies}})) 

--- a/src/clj/kit/spooky_town/web/routes/movie.clj
+++ b/src/clj/kit/spooky_town/web/routes/movie.clj
@@ -1,5 +1,6 @@
 (ns kit.spooky-town.web.routes.movie
   (:require [kit.spooky-town.web.controllers.movie :as movie]
+            [kit.spooky-town.web.controllers.movie-provider :as movie-provider]
             [kit.spooky-town.web.routes.common :refer [authenticated-route-data]]
             [kit.spooky-town.web.middleware.multipart :refer [wrap-multipart-params]]))
 
@@ -123,7 +124,44 @@
                                  [:director-names {:optional true} vector?]
                                  [:release-status keyword?]]}
                       404 {:body empty?}}
-           :handler movie/get-movie-summary}}]])
+           :handler movie/get-movie-summary}}]
+   
+   ["/:movie-uuid/providers"
+    (merge authenticated-route-data
+           {:post {:summary "영화에 OTT 플랫폼 연결"
+                  :parameters {:path [:map [:movie-uuid string?]]
+                             :body [:map [:provider-id string?]]}
+                  :responses {201 {:body [:map [:success boolean?]]}
+                            400 {:body [:map [:error string?]]}
+                            403 {:body [:map [:error string?]]}}
+                  :handler movie-provider/assign-provider}
+
+            :get {:summary "영화의 OTT 플랫폼 목록 조회"
+                 :parameters {:path [:map [:movie-uuid string?]]}
+                 :responses {200 {:body [:map
+                                      [:providers [:vector [:map
+                                                          [:provider-id string?]
+                                                          [:name string?]]]]]}
+                          404 {:body empty?}}
+                 :handler movie-provider/get-providers}
+
+            :delete {:summary "영화에서 OTT 플랫폼 연결 해제"
+                    :parameters {:path [:map [:movie-uuid string?]]
+                               :body [:map [:provider-id string?]]}
+                    :responses {200 {:body [:map [:success boolean?]]}
+                              400 {:body [:map [:error string?]]}
+                              403 {:body [:map [:error string?]]}}
+                    :handler movie-provider/remove-provider}})]
+   
+   ["/providers/:provider-id/movies"
+    {:get {:summary "OTT 플랫폼의 영화 목록 조회"
+           :parameters {:path [:map [:provider-id string?]]}
+           :responses {200 {:body [:map
+                                 [:movies [:vector [:map
+                                                  [:movie-id string?]
+                                                  [:title string?]]]]]}
+                     404 {:body empty?}}
+           :handler movie-provider/get-movies-by-provider}}]])
 
 (defn movie-routes [opts]
   movie-routes-data) 

--- a/src/clj/kit/spooky_town/web/routes/movie.clj
+++ b/src/clj/kit/spooky_town/web/routes/movie.clj
@@ -49,7 +49,8 @@
                              :query [:map
                                     [:include-actors {:optional true} boolean?]
                                     [:include-directors {:optional true} boolean?]
-                                    [:include-theaters {:optional true} boolean?]]}
+                                    [:include-theaters {:optional true} boolean?]
+                                    [:include-providers {:optional true} boolean?]]}
                   :responses {200 {:body [:map
                                         [:movie-uuid string?]
                                         [:title string?]
@@ -73,7 +74,11 @@
                                                   [:vector [:map
                                                            [:theater-uuid string?]
                                                            [:name string?]
-                                                           [:chain-type keyword?]]]]]}
+                                                           [:chain-type keyword?]]]]
+                                        [:providers {:optional true} 
+                                                   [:vector [:map
+                                                            [:provider-id string?]
+                                                            [:name string?]]]]]}
                           404 {:body empty?}}
                   :handler movie/find-movie}
             

--- a/test/clj/kit/spooky_town/domain/common/id/test/uuid_generator.clj
+++ b/test/clj/kit/spooky_town/domain/common/id/test/uuid_generator.clj
@@ -1,7 +1,9 @@
 (ns kit.spooky-town.domain.common.id.test.uuid-generator
   (:require [kit.spooky-town.domain.common.id.protocol :as protocol]))
 
+(defn generate-uuid [_]
+  (throw (ex-info "Not implemented" {})))
+
 (defrecord TestUuidGenerator []
   protocol/UuidGenerator
-  (generate-uuid [_]
-    #uuid "550e8400-e29b-41d4-a716-446655440000")) 
+  (generate-uuid [this] (generate-uuid this))) 

--- a/test/clj/kit/spooky_town/domain/movie/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/use_case_test.clj
@@ -67,6 +67,7 @@
                            :runtime 120
                            :poster-file "path/to/poster.jpg")]
         (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")
+                      uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")
                       director-repository-fixture/find-by-name (constantly nil)
                       director-repository-fixture/save! (fn [_ director] director)
                       movie-director-repository-fixture/save-movie-director!
@@ -88,34 +89,38 @@
                           :theater-infos [{:theater-name "CGV 강남"}
                                         {:theater-name "메가박스 코엑스"}])]
         (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")
-                     director-repository-fixture/find-by-name (constantly nil)
-                     director-repository-fixture/save! (fn [_ director] director)
-                     movie-director-repository-fixture/save-movie-director!
-                     (fn [_ movie-id director-id role]
-                       {:movie-id movie-id :director-id director-id :role role})
-                     theater-repository-fixture/find-id-by-name (constantly nil)
-                     theater-repository-fixture/save! (fn [_ theater] theater)
-                     movie-theater-repository-fixture/save-movie-theater!
-                     (fn [_ movie-id theater-id]
-                       {:movie-id movie-id :theater-id theater-id})
-                     movie-repository-fixture/save! (fn [_ movie] movie)]
+                      uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")
+                      director-repository-fixture/find-by-name (constantly nil)
+                      director-repository-fixture/save! (fn [_ director] director)
+                      movie-director-repository-fixture/save-movie-director!
+                      (fn [_ movie-id director-id role]
+                        {:movie-id movie-id :director-id director-id :role role})
+                      theater-repository-fixture/find-id-by-name (constantly nil)
+                      theater-repository-fixture/save! (fn [_ theater] theater)
+                      movie-theater-repository-fixture/save-movie-theater!
+                      (fn [_ movie-id theater-id]
+                        {:movie-id movie-id :theater-id theater-id})
+                      movie-repository-fixture/save! (fn [_ movie] movie)]
           (let [result (use-case/create-movie movie-use-case command)]
             (is (f/ok? result))
             (is (= "test-id" result))))))
 
     (testing "영화 생성 실패 - 필수 필드 누락"
       (testing "제목 누락"
-        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")]
+        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")
+                      uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")]
           (let [command (dissoc base-command :title)]
             (is (f/failed? (use-case/create-movie movie-use-case command)))))) 
 
       (testing "개봉 정보 누락"
-        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")]
+        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")
+                      uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")]
           (let [command (dissoc base-command :release-info)]
             (is (f/failed? (use-case/create-movie movie-use-case command))))))
 
       (testing "장르 누락"
-        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")]
+        (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")
+                      uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")]
           (let [command (dissoc base-command :genres)]
             (is (f/failed? (use-case/create-movie movie-use-case command)))))))))
 

--- a/test/clj/kit/spooky_town/domain/movie/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie/use_case_test.clj
@@ -51,6 +51,7 @@
 
     (testing "영화 생성 성공 - 필수 필드만"
       (with-redefs [id-generator-fixture/generate-ulid (constantly "test-id")
+                    uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")
                     director-repository-fixture/find-by-name (constantly nil)
                     director-repository-fixture/save! (fn [_ director] director)
                     movie-director-repository-fixture/save-movie-director!

--- a/test/clj/kit/spooky_town/domain/movie_provider/test/repository.clj
+++ b/test/clj/kit/spooky_town/domain/movie_provider/test/repository.clj
@@ -1,0 +1,29 @@
+(ns kit.spooky-town.domain.movie-provider.test.repository
+  (:require [kit.spooky-town.domain.movie-provider.repository.protocol :refer [MovieProviderRepository]]))
+
+(defn save! [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-id [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-uuid [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-movie [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn find-by-provider [_ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defn delete! [_ _ _]
+  (throw (ex-info "Not implemented" {})))
+
+(defrecord TestMovieProviderRepository []
+  MovieProviderRepository
+  (save! [this movie-provider] (save! this movie-provider))
+  (find-by-id [this id] (find-by-id this id))
+  (find-by-uuid [this uuid] (find-by-uuid this uuid))
+  (find-by-movie [this movie-id] (find-by-movie this movie-id))
+  (find-by-provider [this provider-id] (find-by-provider this provider-id))
+  (delete! [this movie-id provider-id] (delete! this movie-id provider-id))) 

--- a/test/clj/kit/spooky_town/domain/movie_provider/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/movie_provider/use_case_test.clj
@@ -1,0 +1,163 @@
+(ns kit.spooky-town.domain.movie-provider.use-case-test
+  (:require [clojure.test :refer :all]
+            [failjure.core :as f]
+            [clojure.tools.logging :as log]
+            [kit.spooky-town.domain.movie-provider.use-case :as sut]
+            [kit.spooky-town.domain.movie-provider.test.repository :refer [->TestMovieProviderRepository]]
+            [kit.spooky-town.domain.movie.test.repository :refer [->TestMovieRepository]]
+            [kit.spooky-town.domain.auth.test.authorization :refer [->TestUserAuthorization]]
+            [kit.spooky-town.domain.common.id.test.generator :refer [->TestIdGenerator]]
+            [kit.spooky-town.domain.common.id.test.uuid-generator :refer [->TestUuidGenerator]]))
+
+(deftest movie-provider-use-case-test
+  (let [with-tx (fn [repos f] (apply f repos))
+        movie-provider-repository (->TestMovieProviderRepository)
+        movie-repository (->TestMovieRepository)
+        user-authorization (->TestUserAuthorization)
+        id-generator (->TestIdGenerator)
+        uuid-generator (->TestUuidGenerator)
+        use-case (sut/->MovieProviderUseCaseImpl
+                  movie-provider-repository
+                  movie-repository
+                  user-authorization
+                  id-generator
+                  uuid-generator
+                  with-tx)
+        
+        ;; 테스트 데이터
+        movie-uuid #uuid "550e8400-e29b-41d4-a716-446655440000"
+        movie-id "01HQ1234567890ABCDEFGHJKLM"
+        provider-id "NETFLIX"
+        user-uuid #uuid "550e8400-e29b-41d4-a716-446655440001"
+        
+        ;; Mock functions
+        save!-fn (atom nil)
+        delete!-fn (atom nil)
+        find-by-movie-fn (atom nil)
+        find-by-provider-fn (atom nil)
+        find-id-by-uuid-fn (atom nil)
+        has-permission?-fn (atom nil)
+        generate-ulid-fn (atom nil)
+        generate-uuid-fn (atom nil)]
+    
+    (with-redefs [kit.spooky-town.domain.movie-provider.test.repository/save! 
+                  (fn [_ provider] 
+                    (log/info "Saving provider:" provider)
+                    (@save!-fn provider))
+                  
+                  kit.spooky-town.domain.movie-provider.test.repository/delete! 
+                  (fn [_ movie-id provider-id]
+                    (log/info "Deleting provider:" {:movie-id movie-id :provider-id provider-id}) 
+                    (@delete!-fn movie-id provider-id))
+                  
+                  kit.spooky-town.domain.movie-provider.test.repository/find-by-movie 
+                  (fn [_ movie-id]
+                    (log/info "Finding by movie:" movie-id)
+                    (@find-by-movie-fn movie-id))
+                  
+                  kit.spooky-town.domain.movie-provider.test.repository/find-by-provider 
+                  (fn [_ provider-id]
+                    (log/info "Finding by provider:" provider-id)
+                    (@find-by-provider-fn provider-id))
+                  
+                  kit.spooky-town.domain.movie.test.repository/find-id-by-uuid
+                  (fn [_ uuid]
+                    (log/info "Finding movie id by uuid:" uuid)
+                    (@find-id-by-uuid-fn uuid))
+                  
+                  kit.spooky-town.domain.auth.test.authorization/has-permission?
+                  (fn [_ user-uuid permission]
+                    (log/info "Checking permission:" {:user-uuid user-uuid :permission permission})
+                    (@has-permission?-fn user-uuid permission))
+                  
+                  kit.spooky-town.domain.common.id.test.generator/generate-ulid
+                  (fn [_]
+                    (log/info "Generating ULID")
+                    (@generate-ulid-fn))
+                  
+                  kit.spooky-town.domain.common.id.test.uuid-generator/generate-uuid
+                  (fn [_]
+                    (log/info "Generating UUID")
+                    (@generate-uuid-fn))]
+      
+      (testing "OTT 플랫폼 연결"
+        (testing "성공 케이스"
+          (reset! has-permission?-fn (constantly true))
+          (reset! find-id-by-uuid-fn (constantly movie-id))
+          (reset! generate-ulid-fn (constantly "01HQ1234567890ABCDEFGHJKLM"))
+          (reset! generate-uuid-fn (constantly #uuid "550e8400-e29b-41d4-a716-446655440000"))
+          (reset! save!-fn identity)
+          
+          (let [result (sut/assign-provider! 
+                        use-case 
+                        {:movie-uuid movie-uuid
+                         :provider-id provider-id
+                         :user-uuid user-uuid})]
+            (log/info "Result:" result)
+            (is (not (f/failed? result)))))
+        
+        (testing "권한이 없는 경우"
+          (reset! has-permission?-fn (constantly false))
+          
+          (let [result (sut/assign-provider! 
+                        use-case 
+                        {:movie-uuid movie-uuid
+                         :provider-id provider-id
+                         :user-uuid user-uuid})]
+            (is (f/failed? result))
+            (is (= "OTT 플랫폼을 연결할 권한이 없습니다." (f/message result)))))
+        
+        (testing "존재하지 않는 영화"
+          (reset! has-permission?-fn (constantly true))
+          (reset! find-id-by-uuid-fn (constantly nil))
+          
+          (let [result (sut/assign-provider! 
+                        use-case 
+                        {:movie-uuid movie-uuid
+                         :provider-id provider-id
+                         :user-uuid user-uuid})]
+            (is (f/failed? result))
+            (is (= "영화를 찾을 수 없습니다." (f/message result))))))
+      
+      (testing "OTT 플랫폼 연결 해제"
+        (testing "성공 ���이스"
+          (reset! has-permission?-fn (constantly true))
+          (reset! find-id-by-uuid-fn (constantly movie-id))
+          (reset! delete!-fn (constantly true))
+          
+          (let [result (sut/remove-provider! 
+                        use-case 
+                        {:movie-uuid movie-uuid
+                         :provider-id provider-id
+                         :user-uuid user-uuid})]
+            (is (not (f/failed? result)))))
+        
+        (testing "권한이 없는 경우"
+          (reset! has-permission?-fn (constantly false))
+          
+          (let [result (sut/remove-provider! 
+                        use-case 
+                        {:movie-uuid movie-uuid
+                         :provider-id provider-id
+                         :user-uuid user-uuid})]
+            (is (f/failed? result))
+            (is (= "OTT 플랫폼 연결을 제거할 권한이 없습니다." (f/message result))))))
+      
+      (testing "영화의 OTT 플랫폼 조회"
+        (reset! find-id-by-uuid-fn (constantly movie-id))
+        (reset! find-by-movie-fn 
+                (constantly [{:provider-id "NETFLIX" :name "Netflix"}]))
+        
+        (let [result (sut/get-providers 
+                      use-case 
+                      {:movie-uuid movie-uuid})]
+          (is (= [{:provider-id "NETFLIX" :name "Netflix"}] result))))
+      
+      (testing "OTT 플랫폼의 영화 조회"
+        (reset! find-by-provider-fn 
+                (constantly [{:movie-id movie-id :title "스크림"}]))
+        
+        (let [result (sut/get-movies-by-provider 
+                      use-case 
+                      {:provider-id provider-id})]
+          (is (= [{:movie-id movie-id :title "스크림"}] result))))))) 

--- a/test/clj/kit/spooky_town/domain/theater/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/theater/use_case_test.clj
@@ -21,6 +21,7 @@
 
     (testing "극장 생성"
       (with-redefs [id-generator-fixture/generate-ulid (constantly "01HQ1234567890ABCDEFGHJKLM")
+                    uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")
                     theater-repository-fixture/save! (fn [_ theater] theater)]
         (let [result (use-case/create-theater! use-case base-command)]
           (is (some? result))

--- a/test/clj/kit/spooky_town/domain/user/use_case_test.clj
+++ b/test/clj/kit/spooky_town/domain/user/use_case_test.clj
@@ -130,6 +130,7 @@
     (testing "유효한 사용자 등록"
       (with-redefs [user-repository-fixture/find-by-email (fn [_ _] nil)
                     id-generator-fixture/generate-ulid (fn [_] "user-01")
+                    uuid-generator-fixture/generate-uuid (constantly #uuid "550e8400-e29b-41d4-a716-446655440000")
                     password-gateway-fixture/hash-password (fn [_ _] "hashed_password")
                     role-repository-fixture/find-by-name (fn [_ _]
                                                          {:id "role-01"


### PR DESCRIPTION
# OTT 플랫폼 연동 기능 추가

## 변경 사항
### 도메인 레이어
- MovieProviderUseCase 구현
  - OTT 플랫폼 연결/해제 기능
  - 영화별 OTT 플랫폼 목록 조회
  - OTT 플랫폼별 영화 목록 조회
- MovieQueryService에 provider 조회 기능 추가
  - find-movie 메서드에 :include-providers 옵션 추가

### 웹 레이어
- MovieProvider 컨트롤러 구현
- Movie 라우트에 provider 관련 엔드포인트 추가:
  - POST /movies/:movie-uuid/providers
  - GET /movies/:movie-uuid/providers
  - DELETE /movies/:movie-uuid/providers
  - GET /movies/providers/:provider-id/movies

### 테스트
- MovieProviderUseCase 테스트 추가
- MovieQueryService 테스트에 provider 관련 케이스 추가
- TestMovieProviderRepository 구현

### 시스템 설정
- system.edn에 필요한 의존성 추가
  - :infrastructure/movie-provider-repository
  - :domain/movie-provider-use-case
  - API 라우터에 의존성 주입 설정

## 관련 이슈
Closes #34 